### PR TITLE
Add boom integration and bootable snapshot sets support

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -22,6 +22,21 @@ jobs:
       - name: Install Snapshot Manager
         run: >
           sudo pip install -v .
+      - name: Check out boom
+        run: git clone https://github.com/snapshotmanager/boom
+        working-directory: /var/tmp
+      - name: Install boom
+        run: sudo python3 setup.py install
+        working-directory: /var/tmp/boom
+      - name: Create boom configuration
+        run: |
+          sudo mkdir /boot/boom
+          sudo mkdir /boot/boom/cache
+          sudo mkdir /boot/boom/hosts
+          sudo mkdir /boot/boom/profiles
+          sudo mkdir -p /boot/loader/entries
+          sudo cp /var/tmp/boom/examples/boom.conf /boot/boom
+          sudo boom profile create --from-host --uname-pattern generic
       - name: Check PyCodestyle
         run: >
           pycodestyle snapm --ignore E501,E203,W503

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -45,12 +45,9 @@ jobs:
       - name: Run bandit
         run: >
           bandit --skip B303,B404,B603 -r snapm
-      - name: Run test suite
+      - name: Run test suite with coverage
         run: >
-          sudo pytest-3 -v
-      - name: Run coverage on test suite
-        run: |
-          sudo python3-coverage run -m unittest discover
+          sudo python3-coverage run /usr/bin/pytest-3 --log-level=debug -v
       - name: Report coverage
         run: >
           python3-coverage report --include "./snapm/*"

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -50,5 +50,5 @@ jobs:
           sudo python3-coverage run /usr/bin/pytest-3 --log-level=debug -v
       - name: Report coverage
         run: >
-          python3-coverage report --include "./snapm/*"
+          python3-coverage report -m --include "./snapm/*"
 

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -36,7 +36,9 @@ jobs:
           sudo mkdir /boot/boom/profiles
           sudo mkdir -p /boot/loader/entries
           sudo cp /var/tmp/boom/examples/boom.conf /boot/boom
+          # Create profiles for kernel variants seen in CI
           sudo boom profile create --from-host --uname-pattern generic
+          sudo boom profile create --from-host --uname-pattern azure
       - name: Check PyCodestyle
         run: >
           pycodestyle snapm --ignore E501,E203,W503

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -44,7 +44,7 @@ jobs:
           pycodestyle snapm --ignore E501,E203,W503
       - name: Run bandit
         run: >
-          bandit --skip B303,B404,B603 -r snapm
+          bandit --skip B101,B303,B404,B603 -r snapm
       - name: Run test suite with coverage
         run: >
           sudo python3-coverage run /usr/bin/pytest-3 --log-level=debug -v

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ deactivate, list and display snapsets.
 ##### create
 Create a new snapset with the provided name and list of mount points.
 ```
-# snapm snapset create <name> mount_point...
+# snapm snapset create [-b|--bootable] [-r|--rollback] <name> mount_point...
 ```
 
 ##### delete
@@ -304,14 +304,16 @@ options:
   -h, --help            show this help message and exit
 
 # snapm snapset create --help
-usage: snapm snapset create [-h] SNAPSET_NAME MOUNT_POINT [MOUNT_POINT ...]
+usage: snapm snapset create [-h] [-b] [-r] SNAPSET_NAME MOUNT_POINT [MOUNT_POINT ...]
 
 positional arguments:
-  SNAPSET_NAME  The name of the snapshot set to create
-  MOUNT_POINT   A list of mount points to include in this snapshot set
+  SNAPSET_NAME    The name of the snapshot set to create
+  MOUNT_POINT     A list of mount points to include in this snapshot set
 
 options:
-  -h, --help    show this help message and exit
+  -h, --help      show this help message and exit
+  -b, --bootable  Create a boot entry for this snapshot set
+  -r, --rollback  Create a rollback boot entry for this snapshot set
 ```
 
 ## Documentation

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -58,6 +58,8 @@ Snapm \(em Linux snapshot manager
 .  ad l
 .  BR snapset
 .  BR \fBcreate
+.  RB [ -b | --bootable ]
+.  RB [ -r | --rollback ]
 .  IR \fIname\fP
 .  IR \fImount_point\fP ...
 .  ad b
@@ -320,6 +322,12 @@ are: manager, command, plugins, report.
 Display usage information and exit.
 .
 .HP
+.BR -b | --bootable
+.br
+When creating snapshot sets automatically create a snapshot boot entry
+for the set.
+.
+.HP
 .BR -n | --name
 .IR name
 .br
@@ -352,6 +360,12 @@ Specify which fields to display.
 .IR sort_fields
 .br
 Specify which fields to sort by.
+.
+.HP
+.BR -r | --rollback
+.br
+When creating snapshot sets automatically create a snapshot rollback entry
+for the set.
 .
 .HP
 .BR --rows
@@ -452,6 +466,10 @@ UUID:         f217177c-f35a-5b57-b33e-4c8ba0bb231a
 .br
 Status:       Inactive
 .br
+
+When creating snapshot sets \fB--bootable\fP and \fB--rollback\fP
+can optionally be used to automatically create snapshot boot and
+rollback boot entries respectively.
 .
 .HP
 .B snapm

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -1,0 +1,314 @@
+# Copyright (C) 2024 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# snapm/manager/boot.py - Snapshot Manager boot support
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""
+Boot integration for snapshot manager
+"""
+from os import uname
+from os.path import exists as path_exists
+import logging
+
+import boom
+import boom.command
+from boom.osprofile import match_os_profile_by_version
+
+from snapm import (
+    SnapmNotFoundError,
+    SnapmCalloutError,
+    SnapmInvalidIdentifierError,
+    ETC_FSTAB,
+)
+
+_log = logging.getLogger(__name__)
+
+_log_debug = _log.debug
+_log_info = _log.info
+_log_warn = _log.warning
+_log_error = _log.error
+
+#: Path to the system machine-id file
+_MACHINE_ID = "/etc/machine-id"
+#: Path to the legacy system machine-id file
+_DBUS_MACHINE_ID = "/var/lib/dbus/machine-id"
+#: Path to the system os-release file
+_OS_RELEASE = "/etc/os-release"
+
+#: Snapshot set kernel command line argument
+SNAPSET_ARG = "snapm.snapset"
+
+#: Snapshot set rollback kernel command line argument
+ROLLBACK_ARG = "snapm.rollback"
+
+
+def _get_uts_release():
+    """
+    Return the UTS release (kernel version) of the running system.
+
+    :returns: A string representation of the UTS release value.
+    """
+    return uname()[2]
+
+
+def _get_machine_id():
+    """
+    Return the current host's machine-id.
+
+    Get the machine-id value for the running system by reading from
+    ``/etc/machine-id`` and return it as a string.
+
+    :returns: The ``machine_id`` as a string
+    :rtype: str
+    """
+    if path_exists(_MACHINE_ID):
+        path = _MACHINE_ID
+    elif path_exists(_DBUS_MACHINE_ID):
+        path = _DBUS_MACHINE_ID
+    else:
+        return None
+
+    with open(path, "r", encoding="utf8") as f:
+        try:
+            machine_id = f.read().strip()
+        except Exception as e:
+            _log_error("Could not read machine-id from '%s': %s", path, e)
+            machine_id = None
+    return machine_id
+
+
+def _find_snapset_root(snapset):
+    """
+    Find the device that backs the root filesystem for snapshot set ``snapset``.
+
+    If the snapset does not include the root volume look the device up via the
+    fstab.
+    """
+    for snapshot in snapset.snapshots:
+        if snapshot.mount_point == "/":
+            return snapshot
+    # FIXME: add fstab lookup for non-root snapsets
+    # needs either root=UUID/LABEL support in boom or a lookup to resolve any
+    # UUID/LABEL found in the file.
+    raise SnapmNotFoundError(f"Could not find root device for snapset {snapset.name}")
+
+
+def _create_default_os_profile():
+    """
+    Create a default boom OsProfile for the running system.
+    This uses the boom API to run the equivalent of:
+      `boom profile create --from-host`.
+    """
+    _log_info("Creating default boot profile from %s", _OS_RELEASE)
+    return boom.command.create_profile(None, None, None, None, profile_file=_OS_RELEASE)
+
+
+def _build_snapset_mount_list(snapset):
+    """
+    Build a list of command line mount unit definitions for the snapshot set
+    ``snapset``. Mount points that are not part of the snapset are substituted
+    from /etc/fstab.
+
+    :param snapset: The snapshot set to build a mount list for.
+    """
+    mounts = []
+    snapset_mounts = snapset.mount_points
+    with open(ETC_FSTAB, "r", encoding="utf8") as fstab:
+        for line in fstab.readlines():
+            if line == "\n" or line.startswith("#"):
+                continue
+            what, where, fstype, options, _, _ = line.split()
+            if where == "/":
+                continue
+            if where in snapset_mounts:
+                snapshot = snapset.snapshot_by_mount_point(where)
+                mounts.append(f"{snapshot.devpath}:{where}:{fstype}:{options}")
+            else:
+                mounts.append(f"{what}:{where}:{fstype}:{options}")
+    return mounts
+
+
+def _create_boom_boot_entry(
+    snapset, title=None, tag_arg=None, root_device=None, mounts=None
+):
+    """
+    Create a boom boot entry to boot into the snapshot set represented by
+    ``snapset``.
+
+    :param snapset: The snapshot set for which to create a boot entry.
+    :param title: An optional title for the boot entry. If ``title`` is
+                  ``None`` the boot entry will be titled as
+                  "Snapshot snapset_name snapset_time".
+    """
+    assert title is not None, "Boot entry argument title must have a value"
+    assert tag_arg is not None, "Boot entry argument tag_arg must have a value"
+    assert root_device is not None, "Boot entry argument root_device must have a value"
+
+    version = _get_uts_release()
+    machine_id = _get_machine_id()
+
+    osp = match_os_profile_by_version(version)
+    if not osp:
+        try:
+            osp = _create_default_os_profile()
+        except ValueError as err:
+            raise SnapmCalloutError(
+                f"Error calling boom to create default OsProfile: {err}"
+            )
+
+    return boom.command.create_entry(
+        title,
+        version,
+        machine_id,
+        root_device,
+        profile=osp,
+        no_fstab=True,
+        mounts=mounts,
+        add_opts=tag_arg,
+    )
+
+
+def create_snapset_boot_entry(snapset, title=None, tag_arg=None):
+    """
+    Create a boom boot entry to boot into the snapshot set represented by
+    ``snapset``.
+
+    :param snapset: The snapshot set for which to create a boot entry.
+    :param title: An optional title for the boot entry. If ``title`` is
+                  ``None`` the boot entry will be titled as
+                  "Snapshot snapset_name snapset_time".
+    """
+    title = title or f"Snapshot {snapset.name} {snapset.time}"
+    root_device = _find_snapset_root(snapset).devpath
+    mounts = _build_snapset_mount_list(snapset)
+    snapset.boot_entry = _create_boom_boot_entry(
+        snapset,
+        title=title,
+        tag_arg=f"{SNAPSET_ARG}={snapset.uuid}",
+        root_device=root_device,
+        mounts=mounts,
+    )
+    _log_debug(
+        "Created boot entry '%s' for snapshot set with UUID=%s", title, snapset.uuid
+    )
+
+
+def create_snapset_rollback_entry(snapset, title=None):
+    """
+    Create a boom boot entry to roll back the snapshot set represented by
+    ``snapset``.
+
+    :param snapset: The snapshot set for which to create a rollback entry.
+    :param title: An optional title for the rollback entry. If ``title`` is
+                  ``None`` the rollback entry will be titled as
+                  "Rollback snapset_name snapset_time".
+    """
+    title = title or f"Rollback {snapset.name} {snapset.time}"
+    root_snapshot = _find_snapset_root(snapset)
+    root_device = root_snapshot.origin
+    snapset.rollback_entry = _create_boom_boot_entry(
+        snapset,
+        title=title,
+        tag_arg=f"{ROLLBACK_ARG}={snapset.uuid}",
+        root_device=root_device,
+    )
+    _log_debug(
+        "Created rollback entry '%s' for snapshot set with UUID=%s", title, snapset.uuid
+    )
+
+
+def delete_snapset_boot_entry(snapset):
+    """
+    Delete the boot entry corresponding to ``snapset``.
+
+    :param snapset: The snapshot set for which to remove a boot entry.
+    """
+    if snapset.boot_entry is None:
+        return
+    selection = boom.Selection(boot_id=snapset.boot_entry.boot_id)
+    boom.command.delete_entries(selection=selection)
+
+
+def delete_snapset_rollback_entry(snapset):
+    """
+    Delete the rollback entry corresponding to ``snapset``.
+
+    :param snapset: The snapshot set for which to remove a rollback entry.
+    """
+    if snapset.rollback_entry is None:
+        return
+    selection = boom.Selection(boot_id=snapset.rollback_entry.boot_id)
+    boom.command.delete_entries(selection=selection)
+
+
+class BootEntryCache(dict):
+    """
+    Cache mapping snapshot sets to boom ``BootEntry`` instances.
+
+    Boot entries in the cache are either snapshot set boot entries or rollback
+    entries depending on the value of ``entry_arg``.
+    """
+
+    def __init__(self, entry_arg):
+        super().__init__()
+        self.entry_arg = entry_arg
+        self.refresh_cache()
+
+    def _parse_entry(self, boot_entry):
+        """
+        Parse a boom ``BootEntry`` options string and return the value
+        of the ``snapm.snapset`` argument if present.
+
+        :param boot_entry: The boot entry to process.
+        :returns: The snapset name for the boot entry.
+        """
+        for word in boot_entry.options.split():
+            if word.startswith(self.entry_arg):
+                _, value = word.split("=")
+                return value
+        return None
+
+    def refresh_cache(self):
+        """
+        Generate mappings from snapshot sets to boot entries.
+        """
+        self.clear()
+        entries = boom.command.find_entries()
+        for boot_entry in entries:
+            snapset = self._parse_entry(boot_entry)
+            if snapset:
+                self[snapset] = boot_entry
+
+
+class BootCache:
+    """
+    Set of caches mapping snapshot sets to boot entries and rollback entries.
+    """
+
+    def __init__(self):
+        self.entry_cache = BootEntryCache(SNAPSET_ARG)
+        _log_debug(
+            "Initialised boot entry cache with %d entries", len(self.entry_cache)
+        )
+        self.rollback_cache = BootEntryCache(ROLLBACK_ARG)
+        _log_debug(
+            "Initialised rollback boot entry cache with %d entries",
+            len(self.rollback_cache),
+        )
+
+    def refresh_cache(self):
+        self.entry_cache.refresh_cache()
+        _log_debug("Refreshed boot entry cache with %d entries", len(self.entry_cache))
+        self.rollback_cache.refresh_cache()
+        _log_debug(
+            "Refreshed rollback boot entry cache with %d entries",
+            len(self.rollback_cache),
+        )

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -339,11 +339,14 @@ class Lvm2Snapshot(Snapshot):
         """
         return ""
 
+    def _devpath(self):
+        return path_join(DEV_PREFIX, self.vg_name, self.lv_name)
+
     @property
     def devpath(self):
         if self.status != SnapStatus.ACTIVE:
             return ""
-        return path_join(DEV_PREFIX, self.vg_name, self.lv_name)
+        return self._devpath()
 
     @property
     def status(self):

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -10,6 +10,7 @@ _LVCREATE_CMD = "lvcreate"
 _VGREMOVE_CMD = "vgremove"
 _VGCHANGE_CMD = "vgchange"
 _LVS_CMD = "lvs"
+_VGS_CMD = "vgs"
 _LVM_CMD = "lvm"
 _LVM_VERSION = "version"
 _LVM_VERSION_STR = "LVM version"
@@ -223,6 +224,9 @@ class LvmLoopBacked(object):
 
     def dump_lvs(self):
         subprocess.check_call([_LVS_CMD])
+
+    def dump_vgs(self):
+        subprocess.check_call([_VGS_CMD])
 
     def destroy(self):
         self.umount_all()

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2024 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# tests/test_boot.py - Boot support tests
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+import unittest
+import tempfile
+import logging
+import os
+from subprocess import run
+from shutil import rmtree
+
+log = logging.getLogger()
+log.level = logging.DEBUG
+log.addHandler(logging.FileHandler("test.log"))
+
+import snapm
+import snapm.manager.boot as boot
+import snapm.manager
+from snapm.manager.plugins import format_snapshot_name, encode_mount_point
+import boom
+
+from ._util import LvmLoopBacked
+
+ETC_FSTAB = "/etc/fstab"
+TMP_FSTAB = "/tmp/fstab"
+
+_VAR_TMP = "/var/tmp"
+
+class BootTestsSimple(unittest.TestCase):
+    """
+    Test boot helpers
+    """
+
+    def test__get_uts_release(self):
+        uname_cmd_args = ["uname", "-r"]
+        uname_cmd = run(uname_cmd_args, capture_output=True, check=True)
+        sys_uts_release = uname_cmd.stdout.decode("utf8").strip()
+        self.assertEqual(sys_uts_release, boot._get_uts_release())
+
+    def test__get_machine_id(self):
+        with open("/etc/machine-id", "r", encoding="utf8") as id_file:
+            sys_machine_id = id_file.read().strip()
+        self.assertEqual(sys_machine_id, boot._get_machine_id())
+
+
+class BootTests(unittest.TestCase):
+    """
+    Test boot integration with devices
+    """
+
+    volumes = ["root", "home", "var"]
+    thin_volumes = ["opt", "srv"]
+    boot_volumes = [
+        ("root", "/"),
+        ("home", "/home"),
+        ("var", "/var"),
+    ]
+
+    def _set_fstab(self):
+        """
+        Set up a fake /etc/fstab to be used for the duration of the test run.
+        """
+        with open(TMP_FSTAB, "w", encoding="utf8") as file:
+            for origin, mp in self.boot_volumes:
+                file.write(f"/dev/test_vg0/{origin}\t{mp}\text4\tdefaults 0 0\n")
+            run(["mount", "--bind", TMP_FSTAB, ETC_FSTAB])
+
+    def _clear_fstab(self):
+        """
+        Remove the fake /etc/fstab.
+        """
+        run(["umount", ETC_FSTAB])
+        os.unlink(TMP_FSTAB)
+
+    def _populate_boom_root_path(self):
+        boot_dir = tempfile.mkdtemp("_snapm_boom_dir", dir=_VAR_TMP)
+        boom_dir = os.path.join(boot_dir, "boom")
+        os.makedirs(os.path.join(boot_dir, "loader", "entries"), exist_ok=True)
+        subdirs = ["cache", "hosts", "profiles"]
+        for subdir in subdirs:
+            os.makedirs(os.path.join(boom_dir, subdir), exist_ok=True)
+        boom_conf = [
+            "[global]\n",
+            f"boot_root = {boot_dir}\n",
+            f"boom_root = %(boot_root)s/boom\n",
+            "[legacy]\n",
+            "enable = False\n",
+            "format = grub1\n",
+            "sync = False\n",
+        ]
+        with open(os.path.join(boom_dir, "boom.conf"), "w", encoding="utf8") as file:
+            file.writelines(boom_conf)
+        return boot_dir
+
+    def _cleanup_boom_root_path(self, boot_path):
+        boom.set_boot_path("/boot")
+        boom.osprofile.load_profiles()
+        boom.bootloader.load_entries()
+        rmtree(boot_path)
+
+    def setUp(self):
+        self._lvm = LvmLoopBacked(self.volumes, thin_volumes=self.thin_volumes)
+        snapset_name = "bootset0"
+        snapset_time = 1707923080
+        for origin, mp in self.boot_volumes:
+            self._lvm.create_snapshot(
+                origin,
+                format_snapshot_name(
+                    origin, snapset_name, snapset_time, encode_mount_point(mp)
+                ),
+            )
+        self.manager = snapm.manager.Manager()
+        self._set_fstab()
+
+    def tearDown(self):
+        self._clear_fstab()
+        self._lvm.destroy()
+
+    def test_create_snapshot_boot_entry_no_id(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_boot_entry()
+
+    def test_create_snapshot_rollback_entry_no_id(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_rollback_entry()
+
+    def test_create_snapshot_boot_entry_bad_name(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_boot_entry(name="bootset1")
+
+    def test_create_snapshot_rollback_entry_bad_name(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_rollback_entry(name="bootset1")
+
+    def test_create_snapshot_boot_entry(self):
+        self.manager.create_snapshot_set_boot_entry(name="bootset0")
+
+        # Clean up boot entry
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_create_snapshot_rollback_entry(self):
+        self.manager.create_snapshot_set_rollback_entry(name="bootset0")
+
+        # Clean up rollback entry
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_create_snapshot_boot_entry_bad_uuid(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_boot_entry(
+                uuid="00000000-0000-0000-0000-000000000000"
+            )
+
+    def test_create_snapshot_rollback_entry_bad_uuid(self):
+        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+            self.manager.create_snapshot_set_rollback_entry(
+                uuid="00000000-0000-0000-0000-000000000000"
+            )
+
+    def test_create_snapshot_boot_entry_uuid(self):
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+        self.manager.create_snapshot_set_boot_entry(uuid=str(sset.uuid))
+
+        # Clean up boot entry
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_create_snapshot_rollback_entry_uuid(self):
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+        self.manager.create_snapshot_set_rollback_entry(uuid=str(sset.uuid))
+
+        # Clean up rollback entry
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_create_boot_entries_and_discovery(self):
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+        self.manager.create_snapshot_set_boot_entry(name="bootset0")
+        self.manager.create_snapshot_set_rollback_entry(name="bootset0")
+
+        # Re-discover snapshot sets w/attached boot entries
+        self.manager.discover_snapshot_sets()
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+
+        # Validate boot entry
+        boot_entry = sset.boot_entry
+        for snapshot in sset.snapshots:
+            self.assertIn(snapshot.devpath, boot_entry.options)
+
+        # Validate roll back entry
+        rollback_entry = sset.rollback_entry
+        root_snapshot = sset.snapshot_by_mount_point("/")
+        self.assertIn(root_snapshot.origin, rollback_entry.options)
+
+        # Clean up boot entries
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_auto_profile_create_boot_entry(self):
+        boot_dir = self._populate_boom_root_path()
+        boom.set_boot_path(boot_dir)
+        boom.osprofile.load_profiles()
+        boom.bootloader.load_entries()
+        self.addCleanup(self._cleanup_boom_root_path, boot_dir)
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+        self.manager.create_snapshot_set_boot_entry(uuid=str(sset.uuid))
+
+        # Clean up boot entry
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -35,6 +35,11 @@ TMP_FSTAB = "/tmp/fstab"
 
 _VAR_TMP = "/var/tmp"
 
+
+def is_redhat():
+    return os.path.exists("/etc/redhat-release")
+
+
 class BootTestsSimple(unittest.TestCase):
     """
     Test boot helpers
@@ -201,6 +206,7 @@ class BootTests(unittest.TestCase):
         # Clean up boot entries
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
+    @unittest.skipIf(not is_redhat(), "profile auto-creation not supported")
     def test_auto_profile_create_boot_entry(self):
         boot_dir = self._populate_boom_root_path()
         boom.set_boot_path(boot_dir)


### PR DESCRIPTION
Add boom integration and support for bootable snapshot sets. This adds the `snapm.manager.boot` module, `Manager` integration, and two new command line options: `-b|--bootable` and `-r|--rollback`. These allow creating a snapshot boot entry and rollback boot entry respectively when creating new snapshot sets.