### PR TITLE
Prerequesites for boot integration

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -341,7 +341,7 @@ Specify which fields to sort by.
 .HP
 .BR --rows
 .br
-Output report columnes as rows
+Output report columns as rows
 .
 .HP
 .BR --separator

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -604,6 +604,13 @@ class Snapshot:
         raise NotImplementedError
 
     @property
+    def origin_options(self):
+        """
+        File system options needed to specify the origin of this snapshot.
+        """
+        raise NotImplementedError
+
+    @property
     def timestamp(self):
         """
         The numerical timestamp of this snapshot.

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -321,7 +321,17 @@ class Lvm2Snapshot(Snapshot):
 
     @property
     def origin(self):
-        return path_join(self.vg_name, self._origin)
+        return path_join(DEV_PREFIX, self.vg_name, self._origin)
+
+    @property
+    def origin_options(self):
+        """
+        File system options needed to specify the origin of this snapshot.
+
+        No file system options are requires for LVM2 block snapshots: always
+        return the empty string.
+        """
+        return ""
 
     @property
     def devpath(self):
@@ -477,7 +487,7 @@ class _Lvm2(Plugin):
         :param timestamp: The snapshot set timestamp.
         :param mount_point: The mount point of the snapshot.
         """
-        (vg_name, lv_name) = origin.split("/")
+        (_, _, vg_name, lv_name) = origin.split("/")
         new_name = format_snapshot_name(
             origin, snapset_name, timestamp, encode_mount_point(mount_point)
         )

--- a/snapm/report.py
+++ b/snapm/report.py
@@ -32,12 +32,29 @@ import sys
 import uuid
 
 
-# FIXME boom integration will need to define this for boot_id values.
-def find_minimum_sha_prefix(_shas, _min_prefix):
+def find_minimum_sha_prefix(shas, min_prefix):
+    """Find the minimum SHA prefix length guaranteeing uniqueness.
+
+    Find the minimum unique prefix for the set of SHA IDs in the set
+    ``shas``.
+
+    :param shas: A set of SHA IDs
+    :param min_prefix: Initial minimum prefix value
+    :returns: The minimum unique prefix length for the set
+    :rtype: int
     """
-    Return the minimum SHA prefix for this report.
-    """
-    return 7
+    shas = list(shas)
+    shas.sort()
+    for sha in shas:
+        if shas.index(sha) == len(shas) - 1:
+            continue
+
+        def _next_sha(shas, sha):
+            return shas[shas.index(sha) + 1]
+
+        while sha[:min_prefix] == _next_sha(shas, sha)[:min_prefix]:
+            min_prefix += 1
+    return min_prefix
 
 
 _log = logging.getLogger(__name__)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -619,11 +619,11 @@ class ReportTests(unittest.TestCase):
         opts = ReportOpts(report_file=output)
 
         xoutput = (
-            "Name     Number   Sha     Time                Uuid                                 StrList        \n"
-            "foo             1 fffffff 2023-09-05 14:40:53 00000000-0000-0000-0000-000000000000 bar, baz, foo  \n"
-            "bar             2 FFFFFFF 1978-01-10 09:13:12 1d133bcc-6137-5267-b870-e469f7188dbe one, three, two\n"
-            "baz             3 1111111 2022-08-01 16:43:32 3576355e-e4d7-5a57-9f24-b3f4e0e326ef baz, quux      \n"
-            "qux             4 2222222 2020-01-01 23:32:08 046e4f15-1ddd-5724-b032-878248a71d4b list, string   \n"
+            "Name     Number   Sha      Time                Uuid                                 StrList        \n"
+            "foo             1 ffffffff 2023-09-05 14:40:53 00000000-0000-0000-0000-000000000000 bar, baz, foo  \n"
+            "bar             2 FFFFFFFF 1978-01-10 09:13:12 1d133bcc-6137-5267-b870-e469f7188dbe one, three, two\n"
+            "baz             3 11111111 2022-08-01 16:43:32 3576355e-e4d7-5a57-9f24-b3f4e0e326ef baz, quux      \n"
+            "qux             4 22222222 2020-01-01 23:32:08 046e4f15-1ddd-5724-b032-878248a71d4b list, string   \n"
         )
 
         pr = Report(


### PR DESCRIPTION
Merge the prereqs for the boot integration work separately, so that the actual boot changes can go in after `snapm snapset rollback` has been implemented. The rollback boot entries provided by [bmr-boot-integration](https://github.com/snapshotmanager/snapm/tree/bmr-boot-integration) require this feature to be functional.