### PR TITLE
Implement roll back operation for snapshot sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ provisioned snapshots are supported.
                 * [create](#create)
                 * [delete](#delete)
                 * [rename](#rename)
+                * [rollback](#rollback)
                 * [activate](#activate)
                 * [deactivate](#deactivate)
                 * [autoactivate](#autoactivate)
@@ -112,6 +113,19 @@ Delete an existing snapset by name or uuid.
 Rename an existing snapset.
 ```
 # snapm snapset rename <old_name> <new_name>
+```
+
+##### rollback
+Roll back an existing snapset, re-setting the content of the origin volumes
+to the state they were in at the time the snapset was created. The snapset
+to be rolled back may be specified either by its name or uuid.
+
+Rolling back a snapshot set with mounted and in-use origin volumes will
+schedule the roll back to take place the next time that the volumes are
+activated, for example by booting into a configured rollback boot entry for
+the snapshot set.
+```
+# snapm snapset rollback <name|uuid>
 ```
 
 ##### activate

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -93,6 +93,21 @@ Snapm \(em Linux snapshot manager
 .
 .HP
 .B snapm
+.de CMD_SNAPSET_ROLLBACK
+.  ad l
+.  BR snapset
+.  BR \fBrollback
+.  IR [ name | uuid ]
+.  RB [ --name
+.  IR name ]
+.  RB [ --uuid
+.  IR uuid ]
+.  ad b
+..
+.CMD_SNAPSET_ROLLBACK
+.
+.HP
+.B snapm
 .de CMD_SNAPSET_ACTIVATE
 .  ad l
 .  BR snapset
@@ -451,6 +466,19 @@ either by its \fBname\fP or \fBuuid\fP.
 .br
 Rename an existing snapset. The snapset to be renamed is specified as
 \fBold_name\fP and the new name is given as \fBnew_name\fP.
+.
+.HP
+.B snapm
+.CMD_SNAPSET_ROLLBACK
+.br
+Roll back an existing snapset, re-setting the content of the origin volumes
+to the state they were in at the time the snapset was created. The snapset
+to be rolled back may be specified either by its \fBname\fP or \fBuuid\fP.
+
+Rolling back a snapshot set with mounted and in-use origin volumes will
+schedule the roll back to take place the next time that the volumes are
+activated, for example by booting into a configured rollback boot entry for
+the snapshot set.
 .
 .HP
 .B snapm

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -691,6 +691,16 @@ class Snapshot:
             self.name, self.origin, new_name, self.timestamp, self.mount_point
         )
 
+    def rollback(self):
+        """
+        Request to roll back a snapshot and revert the content of the origin
+        volume to its state at the time of the snapshot.
+
+        This may be deferred until the next device activation or mount
+        operation for the respective volume.
+        """
+        self._provider.rollback_snapshot(self.name)
+
     def invalidate_cache(self):
         """
         Invalidate any cached data describing this snapshot.

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -342,18 +342,6 @@ def rename_snapset(manager, old_name, new_name):
     return manager.rename_snapshot_set(old_name, new_name)
 
 
-def _expand_fields(default_fields, output_fields):
-    """
-    Expand output fields list from command line arguments.
-    """
-
-    if not output_fields:
-        output_fields = default_fields
-    elif output_fields.startswith("+"):
-        output_fields = default_fields + "," + output_fields[1:]
-    return output_fields
-
-
 def show_snapshots(manager, selection=None):
     """
     Show snapshots matching selection criteria.
@@ -377,6 +365,18 @@ def show_snapsets(manager, selection=None, members=False):
                 print(_str_indent(str(snapshot), 4))
                 print()
         print()
+
+
+def _expand_fields(default_fields, output_fields):
+    """
+    Expand output fields list from command line arguments.
+    """
+
+    if not output_fields:
+        output_fields = default_fields
+    elif output_fields.startswith("+"):
+        output_fields = default_fields + "," + output_fields[1:]
+    return output_fields
 
 
 def print_snapshots(

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -122,6 +122,12 @@ LVCHANGE_SETACTIVATIONSKIP = "--setactivationskip"
 LVCHANGE_ACTIVATIONSKIP_YES = "y"
 LVCHANGE_ACTIVATIONSKIP_NO = "n"
 
+# lvconvert command
+LVCONVERT_CMD = "lvconvert"
+
+# lvconvert command options
+LVCONVERT_MERGE = "--merge"
+
 # dmsetup options
 DMSETUP_CMD = "dmsetup"
 DMSETUP_SPLITNAME = "splitname"
@@ -511,6 +517,25 @@ class _Lvm2(Plugin):
             vg_name,
             lv_name,
         )
+
+    def rollback_snapshot(self, name):
+        """
+        Roll back the state of the content of the origin to the content at the
+        time the snapshot was taken.
+
+        For LVM2 snapshots of in-use logical volumes this will take place at
+        the next activation (typically a reboot into the rollback boot entry
+        for the snapshot set).
+        """
+        lvconvert_cmd = [
+            LVCONVERT_CMD,
+            LVCONVERT_MERGE,
+            name,
+        ]
+        try:
+            run(lvconvert_cmd, capture_output=True, check=True)
+        except CalledProcessError as err:
+            raise SnapmCalloutError(f"{LVCONVERT_CMD} failed with: {err}") from err
 
     def _activate(self, active, name, silent=False):
         lvchange_cmd = [

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,5 +1,6 @@
 import tempfile
 import subprocess
+from pathlib import Path
 import os
 
 _LOSETUP_CMD = "losetup"
@@ -7,6 +8,7 @@ _LOSETUP_CMD = "losetup"
 _VGCREATE_CMD = "vgcreate"
 _LVCREATE_CMD = "lvcreate"
 _VGREMOVE_CMD = "vgremove"
+_VGCHANGE_CMD = "vgchange"
 _LVS_CMD = "lvs"
 _LVM_CMD = "lvm"
 _LVM_VERSION = "version"
@@ -191,20 +193,41 @@ class LvmLoopBacked(object):
             [_MOUNT_CMD, f"/dev/{_VG_NAME}/{name}", f"{self.mount_root}/{name}"]
         )
 
+    def mount_all(self):
+        for lv in self.all_volumes():
+            self.mount(lv)
+
     def umount(self, name):
         subprocess.check_call([_UMOUNT_CMD, f"{self.mount_root}/{name}"])
 
+    def umount_all(self):
+        for lv in self.all_volumes():
+            self.umount(lv)
+
+    def activate(self):
+        subprocess.check_call([_VGCHANGE_CMD, "-ay", _VG_NAME])
+
+    def deactivate(self):
+        subprocess.check_call([_VGCHANGE_CMD, "-an", _VG_NAME])
+
     def mount_points(self):
         return [f"{self.mount_root}/{name}" for name in self.all_volumes()]
+
+    def touch_path(self, relpath):
+        path = Path(f"{self.mount_root}/{relpath}")
+        path.touch()
+
+    def test_path(self, relpath):
+        path = Path(f"{self.mount_root}/{relpath}")
+        return path.exists()
 
     def dump_lvs(self):
         subprocess.check_call([_LVS_CMD])
 
     def destroy(self):
+        self.umount_all()
         for lv in self.all_volumes():
-            self.umount(lv)
             os.rmdir(f"{self.mount_root}/{lv}")
-
         os.rmdir(self.mount_root)
 
         subprocess.check_call([_VGREMOVE_CMD, "--force", "--yes", _VG_NAME])


### PR DESCRIPTION
Add the ability to roll back a snapshot set, causing each origin to revert to the state at the time the snapshot set was taken. This adds a new `Plugin` method `rollback_snapshot()` and a corresponding snapshot method `Snapshot.rollback()`. The `Manager` method `rollback_snapshot_sets()` initiates roll back for a snapshot set as a whole.