### PR TITLE
Fix Manager.create_snapshot_set() error propagation

### DIFF
--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -543,6 +543,7 @@ class Manager:
                 _log_error("Error creating snapshot set member %s: %s", name, err)
                 for snapshot in snapshots:
                     snapshot.delete()
+                raise err
         snapset = SnapshotSet(name, timestamp, snapshots)
         for snapshot in snapset.snapshots:
             snapshot.snapshot_set = snapset

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -25,8 +25,8 @@ _THIN_POOL_NAME = "pool0"
 
 _VAR_TMP = "/var/tmp"
 
-# 10GiB
-_LOOP_DEVICE_SIZE = 10 * 1024**3
+# 20GiB
+_LOOP_DEVICE_SIZE = 12 * 1024**3
 
 # 1GiB
 _LV_SIZE = 1024**3

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -257,6 +257,12 @@ class ManagerTests(unittest.TestCase):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
             self.manager.create_snapshot_set(name, self._lvm.mount_points())
 
+    def test_create_snapshot_set_no_space_raises(self):
+        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
+        with self.assertRaises(snapm.SnapmNoSpaceError) as cm:
+            self.manager.create_snapshot_set("testset2", self._lvm.mount_points())
+
     def test_create_delete_snapshot_set(self):
         self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
         s = snapm.Selection(name="testset0")


### PR DESCRIPTION
The create_snapshot_set() method fails to propagate exceptions that are raised during snapshot creation. This leeds to it incorrectly reporting success when snapshot set creation has failed. Fix this by re-raising the original exception after performing cleanup tasks.