### PR TITLE
Fix boot integration bugs

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -531,6 +531,21 @@ class SnapshotSet:
         """
         return all(s.autoactivate for s in self.snapshots)
 
+    @autoactivate.setter
+    def autoactivate(self, value):
+        """
+        Set the autoactivation status for all snapshots in this snapshot set.
+        """
+        for snapshot in self.snapshots:
+            try:
+                snapshot.set_autoactivate(auto=value)
+            except SnapmError as err:
+                _log_error(
+                    "Failed to set autoactivation for snapshot set member %s: %s",
+                    snapshot.name,
+                    err,
+                )
+
     def snapshot_by_mount_point(self, mount_point):
         """
         Return the snapshot corresponding to ``mount_point``.

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -351,14 +351,14 @@ def create_snapset(manager, name, mount_points, boot=False, rollback=False):
     if boot:
         try:
             manager.create_snapshot_set_boot_entry(name=snapset.name)
-        except (OSError, ValueError) as err:
+        except (OSError, ValueError, TypeError) as err:
             _log_error("Failed to create snapshot set boot entry: %s", err)
             manager.delete_snapshot_sets(select)
             return None
     if rollback:
         try:
             manager.create_snapshot_set_rollback_entry(name=snapset.name)
-        except (OSError, ValueError) as err:
+        except (OSError, ValueError, TypeError) as err:
             _log_error("Failed to create snapshot set rollback boot entry: %s", err)
             manager.delete_snapshot_sets(select)
             return None

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -784,6 +784,12 @@ class Manager:
         else:
             raise SnapmNotFoundError("A snapshot set name or UUID is required")
 
+        snapset.autoactivate = True
+        if not snapset.autoactivate:
+            raise SnapmError(
+                "Could not enable autoactivation for all snapshots in snapshot "
+                f"set {snapset.name}"
+            )
         if snapset.boot_entry is not None:
             raise SnapmExistsError(
                 f"Boot entry already associated with snapshot set {snapset.name}"

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -766,15 +766,7 @@ class Manager:
                 f"Could not find snapshot sets matching {selection}"
             )
         for snapset in sets:
-            for snapshot in snapset.snapshots:
-                try:
-                    snapshot.set_autoactivate(auto=auto)
-                except SnapmError as err:
-                    _log_error(
-                        "Failed to set autoactivation for snapshot set member %s: %s",
-                        snapshot.name,
-                        err,
-                    )
+            snapset.autoactivate = auto
             changed += 1
         return changed
 


### PR DESCRIPTION
Fix two problems in the boot integration:

* Snapshot sets need to be set to autoactivate when creating boot entries.
* Snapshot manager needs to pass the `lvm_root_lv` argument to `boom.create_entry()` in order to generate the correct `rd.lvm.lv` syntax in generated boot entries
