### PR TITLE
Only pass no_fstab=True if command line mounts are defined

### DIFF
--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -174,7 +174,7 @@ def _create_boom_boot_entry(
         root_device,
         lvm_root_lv=lvm_root_lv,
         profile=osp,
-        no_fstab=True,
+        no_fstab=True if mounts else False,
         mounts=mounts,
         add_opts=tag_arg,
     )


### PR DESCRIPTION
Use the normal fstab generator logic when creating boot entries without an explicit mounts list.