### PR TITLE
snapm: add SnapmPluginError and improve error message on set create

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -192,6 +192,12 @@ class SnapmParseError(SnapmError):
     """
 
 
+class SnapmPluginError(SnapmError):
+    """
+    An error performing an action via a plugin.
+    """
+
+
 #
 # Selection criteria class
 #
@@ -964,6 +970,7 @@ __all__ = [
     "SnapmNotFoundError",
     "SnapmInvalidIdentifierError",
     "SnapmParseError",
+    "SnapmPluginError",
     "Selection",
     "size_fmt",
     "is_size_policy",

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -682,7 +682,9 @@ class Manager:
                 self.by_name[old_snapset.name] = old_snapset
                 self.by_uuid[str(old_snapset.uuid)] = old_snapset
                 self.snapshot_sets.append(old_snapset)
-                raise err
+                raise SnapmPluginError(
+                    f"Could not rename all snapshots for set {old_name}"
+                )
 
         new_snapset = SnapshotSet(new_name, timestamp, new_snapshots)
         for snapshot in new_snapset.snapshots:
@@ -716,6 +718,9 @@ class Manager:
                         snapshot.name,
                         err,
                     )
+                    raise SnapmPluginError(
+                        f"Could not delete all snapshots for set {snapset.name}"
+                    )
 
             self.snapshot_sets.remove(snapset)
             self.by_name.pop(snapset.name)
@@ -748,6 +753,9 @@ class Manager:
                         snapshot.name,
                         err,
                     )
+                    raise SnapmPluginError(
+                        f"Could not roll back all snapshots for set {snapset.name}"
+                    )
             rolled_back += 1
         return rolled_back
 
@@ -773,6 +781,9 @@ class Manager:
                         snapshot.name,
                         err,
                     )
+                    raise SnapmPluginError(
+                        f"Could not activate all snapshots for set {snapset.name}"
+                    )
             activated += 1
         return activated
 
@@ -797,6 +808,9 @@ class Manager:
                         "Failed to deactivate snapshot set member %s: %s",
                         snapshot.name,
                         err,
+                    )
+                    raise SnapmPluginError(
+                        f"Could not deactivate all snapshots for set {snapset.name}"
                     )
             deactivated += 1
         return deactivated
@@ -837,7 +851,7 @@ class Manager:
 
         snapset.autoactivate = True
         if not snapset.autoactivate:
-            raise SnapmError(
+            raise SnapmPluginError(
                 "Could not enable autoactivation for all snapshots in snapshot "
                 f"set {snapset.name}"
             )

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -40,6 +40,7 @@ from snapm import (
     SnapmPathError,
     SnapmNotFoundError,
     SnapmInvalidIdentifierError,
+    SnapmPluginError,
     Selection,
     is_size_policy,
     SnapshotSet,
@@ -620,7 +621,7 @@ class Manager:
                 _log_error("Error creating snapshot set member %s: %s", name, err)
                 for snapshot in snapshots:
                     snapshot.delete()
-                raise err
+                raise SnapmPluginError(f"Could not create all snapshots for set {name}")
 
         for provider in set(provider_map.values()):
             provider.end_transaction()


### PR DESCRIPTION
When a plugin operation fails with e.g. SnapmCalloutError, catch the initial exception and then re-raise a new exception type, SnapmPluginError with a more descriptive error message.

This changes failure in lvcreate from:

```
# snapm snapset create backup-plus /:10%FREE /home /var
ERROR - Error creating snapshot set member backup-plus: lvcreate failed with:   Size is not a multiple of 512. Try using 2384881152 or 2384881664.
  Invalid argument for --size: 2384881255b
  Error during parsing of command line.

ERROR - Command failed: lvcreate failed with:   Size is not a multiple of 512. Try using 2384881152 or 2384881664.
  Invalid argument for --size: 2384881255b
  Error during parsing of command line.
```

Which just duplicates the LVM2 error message to:

```
# snapm snapset create backup-plus /:10%FREE /home /var
ERROR - Error creating snapshot set member backup-plus: lvcreate failed with:   Size is not a multiple of 512. Try using 2384881152 or 2384881664.
  Invalid argument for --size: 2384881255b
  Error during parsing of command line.

ERROR - Command failed: Could not create all snapshots for set backup-plus
```

The sector rounding bug is already fixed in `main` but this will cover any future error of the same type.

Use the new error type consistently in the create, rename, delete, rollback, activate and deactivate paths.