### PR TITLE
snapm: use rsplit() to parse size policy from mount spec

### DIFF
--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -566,7 +566,7 @@ class Manager:
         # Parse size policies and normalise mount paths
         for mp_spec in mount_point_specs:
             if ":" in mp_spec:
-                (mount, policy) = mp_spec.split(":", maxsplit=1)
+                (mount, policy) = mp_spec.rsplit(":", maxsplit=1)
                 if not is_size_policy(policy):
                     mount = f"{mount}:{policy}"
                     policy = default_size_policy


### PR DESCRIPTION
If mount paths contain the ':' character we only want to split at the rightmost occurence when checking for a size policy string.

Fixes:
snapm snapset create backup-plus --size-policy 100%SIZE /:2G /home /var /mnt/foo\:bar/:10%FREE /mnt/foo.bar/ ERROR - Command failed: Path '/mnt/foo' is not a mount point

Related: #19