### PR TITLE
Update snapm.8 manual page

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -533,6 +533,7 @@ Time:           2024-06-05 18:43:43
 UUID:           51b14f55-5281-54ca-87b9-1ff4991cb830
 .br
 Status:         Inactive
+
 .br
 Snapshot providers that do not allocate a fixed size for snapshot data ignore
 any size policy specified on the command line.

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -851,7 +851,7 @@ backup       /dev/fedora/var  /var             Active   5.8GiB 5.8GiB yes       
 backup       /dev/fedora/home /home            Inactive 1.0GiB 1.9GiB no           lvm2-thin
 .br
 .P
-Create a new snapset from the mount points /, /home, and /var
+Create a new snapshot set from the mount points /, /home, and /var
 .br
 #
 .B snapm snapset create backup / /home /var
@@ -867,6 +867,28 @@ Time:         2023-11-21 16:01:31
 UUID:         fb76b84b-b615-5aa7-8b2c-713614794a12
 .br
 Status:       Active
+.P
+Create a bootable snapshot set from the mount points /, /home, and /var
+.br
+#
+.B snapm snapset create upgrade -rb / /home /var
+.br
+SnapsetName:    upgrade
+.br
+MountPoints:    /, /home, /var
+.br
+NrSnapshots:    3
+.br
+Time:           2024-06-06 13:19:15
+.br
+UUID:           5c38930a-6907-54a3-9482-3f2b29a5fc09
+.br
+Status:         Active
+.br
+Boot entry:     b0eb722
+.br
+Rollback entry: c707e9c
+.br
 .P
 Delete the snapset named 'backup'
 .br
@@ -888,56 +910,60 @@ Rename the snapset 'backup' to 'oldbackup'
 .B snapm snapset rename backup oldbackup
 .br
 .P
-Display the snapset named 'oldbackup'
+Display the snapset named 'upgrade'
 .br
 #
-.B snapm snapset show oldbackup
+.B snapm snapset show upgrade
 .br
-SnapsetName:  oldbackup
+SnapsetName:    upgrade
 .br
-MountPoints:  /home, /, /var
+MountPoints:    /, /var, /home
 .br
-NrSnapshots:  3
+NrSnapshots:    3
 .br
-Time:         2023-11-21 16:01:31
+Time:           2024-06-06 13:19:15
 .br
-UUID:         f78f69a5-b589-5fbe-a801-3b48d90eec10
+UUID:           5c38930a-6907-54a3-9482-3f2b29a5fc09
 .br
-Status:       Active
+Status:         Active
+.br
+Boot entry:     b0eb722
+.br
+Rollback entry: c707e9c
 .br
 .P
-Display the snapshot with UUID f8cc06e3-780e-5bb4-aa5f-c5aa155a25ce
+Display the snapshot with UUID 96a652ed-1951-569e-86bf-ad2bafcce9d9
 .br
 #
-.B snapm snapshot show -U f8cc06e3-780e-5bb4-aa5f-c5aa155a25ce
+.B snapm snapshot show -U 96a652ed-1951-569e-86bf-ad2bafcce9d9
 .br
-Name:           fedora/root-snapset_backup_1717609423_-
+Name:           fedora/root-snapset_upgrade_1717676355_-
 .br
-SnapsetName:    backup
+SnapsetName:    upgrade
 .br
 Origin:         /dev/fedora/root
 .br
-Time:           2024-06-05 18:43:43
+Time:           2024-06-06 13:19:15
 .br
 MountPoint:     /
 .br
 Provider:       lvm2-cow
 .br
-UUID:           f8cc06e3-780e-5bb4-aa5f-c5aa155a25ce
+UUID:           96a652ed-1951-569e-86bf-ad2bafcce9d9
 .br
 Status:         Active
 .br
-Size:           4.0GiB
+Size:           6.1GiB
 .br
-Free:           4.0GiB
+Free:           6.1GiB
 .br
 Autoactivate:   yes
 .br
-DevicePath:     /dev/fedora/root-snapset_backup_1717609423_-
+DevicePath:     /dev/fedora/root-snapset_upgrade_1717676355_-
 .br
 VolumeGroup:    fedora
 .br
-LogicalVolume:  root-snapset_backup_1717609423_-
+LogicalVolume:  root-snapset_upgrade_1717676355_-
 .br
 .P
 .SH AUTHORS

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -421,9 +421,9 @@ Display the version of \fBsnapm\fP and exit.
 Snapm manages named collections of snapshots taken at a common point in time as
 \fIsnapshot sets\fP. A snapshot set is created from a list of mount points and
 allows the state of the system to be captured spanning over several volumes.
-Snapset names cannot include the forward slash ('/') or underscore ('_')
-characters. Snapshot sets and snapshots are also identified by a unique UUID
-value. The terms \fIsnapshot set\fP and \fIsnapset\fP are used interchangeable
+Valid characters for snapset names are A-Z, a-z, 0-9, -, ., and +. Snapshot sets
+and snapshots are also identified by a unique UUID value. The terms \fIsnapshot
+set\fP and \fIsnapset\fP are used interchangeable
 in this manual page.
 
 A plugin model is used to map mount points onto possible snapshot

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -696,6 +696,31 @@ that field respectively.
 .br
 Display snapshots matching selection criteria on standard out.
 .
+.SH BOOTING AND ROLLING BACK SNAPSHOT SETS
+.
+Snapshot manager integrates with the \fBboom(8)\fP boot manager to facilitate
+booting and rolling back snapshot sets. Specifying the \fB-b|--bootable\fP or
+\fB-r|--rollback\fP arguments when creating a snapshot set will cause
+\fBsnapm\fP to create a snapshot boot or rollback boot entry respectively. In
+order for a snapshot set to be made with boot or rollback support it must
+include a snapshot of the root filesystem.
+
+The snapshot boot entry allows the system to boot into the state of the system
+at the time the snapshot was created. This can be used to inspect the previous
+state of the system or to quickly recover from a failed update or
+reconfiguration.
+
+In order to reset the system back to the state at the time the snapshot set was
+created the rollback boot entry is used \fIafter\fP issuing a \fBsnapm snapset
+rollback\fP command. After running the \fBrollback\fP command the system should
+be rebooted into the rollback boot entry. This will start the rollback
+operation on all affected volumes.
+
+Note that rolling back a snapshot set will also destroy the snapshot set since
+the snapshot volumes are folded back into the origin devices. Following the
+rollback the snapshot set will no longer appear in the output of \fBsnapm
+snapset list\fP or \fBsnapm snapset show\fP commands.
+.
 .SH REPORTING COMMANDS
 .
 Both the \fBsnapset list\fP and \fBsnapshot list\fP commands use a common
@@ -972,7 +997,11 @@ Bryn M. Reeves <bmr@redhat.com>
 .
 .SH SEE ALSO
 .
+.BR boom(8)
+.br
 Snapm project page: https://github.com/snapshotmanager/snapm
+.br
+Boom project page: https://github.com/snapshotmanager/boom
 .br
 LVM2 resource page: https://www.sourceware.org/lvm2/
 .br

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -610,11 +610,12 @@ Output a tabular report of snapsets.
 Displays a report with one snapset per line, containing fields describing the
 properties of the configured snapshot sets.
 
-The list of fields to display is given with \fB--options\fP as a comma separated
-list of field names. To obtain a list of available fields run '\fBsnapm snapset
-list -o help\fP'. If the list of fields begins with the '\fB+\fP' character the
-specified fields are appended to the default field list. Otherwise the given
-list of fields replaces the default set of report fields.
+The list of fields to display is given with \fB-o|--options\fP as a comma
+separated list of field names. To obtain a list of available fields run
+\&'\fBsnapm snapset list -o help\fP'. If the list of fields begins with the
+\&'\fB+\fP' character the specified fields are appended to the default field
+list. Otherwise the given list of fields replaces the default set of report
+fields.
 
 Report output may be sorted by multiple user-defined keys using the \fB--sort\fP
 option. The option expects a comma separated list of keys, with optional

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -423,13 +423,12 @@ Snapm manages named collections of snapshots taken at a common point in time as
 allows the state of the system to be captured spanning over several volumes.
 Valid characters for snapset names are A-Z, a-z, 0-9, -, ., and +. Snapshot sets
 and snapshots are also identified by a unique UUID value. The terms \fIsnapshot
-set\fP and \fIsnapset\fP are used interchangeable
-in this manual page.
+set\fP and \fIsnapset\fP are used interchangeably in this manual page.
 
 A plugin model is used to map mount points onto possible snapshot
 \fIproviders\fP. A provider plugin must exist for each mount point specified
 when creating a snapshot set. The current plugins support LVM2 copy-on-write and
-thinly provisioned snapshots.
+LVM2 thinly provisioned snapshots.
 
 The \fIsnapset\fP subcommand allows snapsets to be created, deleted,
 enumerated, renamed and activated or deactivated.

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -431,7 +431,7 @@ when creating a snapshot set. The current plugins support LVM2 copy-on-write and
 LVM2 thinly provisioned snapshots.
 
 The \fIsnapset\fP subcommand allows snapsets to be created, deleted,
-enumerated, renamed and activated or deactivated.
+enumerated, renamed, rolled back, and activated or deactivated.
 
 The \fIsnapshot\fP subcommand provides access to information describing
 individual snapshots that are part of a snapshot set, for example the device

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -768,6 +768,18 @@ The list of mount points contained in this snapshot set.
 .B status
 The current status of this snapshot set. Possible values are \fIActive\fP,
 \fIInactive\fP, and \fIInvalid\fP.
+.TP
+.B autoactivate
+The autoactivation setting for this snapshot set.
+.TP
+.B bootentry
+The \fBboot identifier\fP of the boot loader entry configured to boot this
+snapshot set, or the empty string if no boot entry has been created.
+.TP
+.B rollbackentry
+The \fBboot identifier\fP of the boot loader entry configured to roll back
+this snapshot set following a merge operation, or the empty string if no
+rollback boot entry has been created.
 .
 .SS Snapshots
 .

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -477,6 +477,10 @@ A percentage of the size of the origin volume from 0 to 100%.
 .PD
 .
 .P
+.br
+The default size policy for all volumes if none is specified is 200%USED.
+.
+.P
 .B Snapshot Set Commands
 .P
 .

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -1,4 +1,4 @@
-.TH SNAPM 8 "Nov 21 2023" "Linux" "MAINTENANCE COMMANDS"
+.TH SNAPM 8 "Jun 6 2024" "Linux" "MAINTENANCE COMMANDS"
 
 .de ARG_GLOBAL
 .  RI [ global_args ]


### PR DESCRIPTION
- Properly describe the list of invalid characters for snapshot set names
- Also fix typo: The terms snapshot set and snapset are used interchangeable in this manual page.: "interchangeably".
- "LVM2 copy-on-write and thinly provisioned snapshots.": "LVM2 copy-on-write and LVM2 thinly provisioned snapshots."
- "The snapset subcommand allows snapsets to be created, deleted, enumerated, renamed, rolled back and activated or deactivated.
- Size policies add: "The default size policy for all volumes if none is specified is 200%USED".
- Add section on rolling back snapshot sets.
- Add breaks around size policy example
- fields to display is given with --options: "-o|--options"
- REPORT FIELDS: add bootentry and rollbackentry to Snapshot Sets
- EXAMPLES: update the snapset/snapshot show output
