### PR TITLE
Handle systemd-remount-fs changes

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -37,8 +37,8 @@ jobs:
           sudo mkdir -p /boot/loader/entries
           sudo cp /var/tmp/boom/examples/boom.conf /boot/boom
           # Create profiles for kernel variants seen in CI
-          sudo boom profile create --from-host --uname-pattern generic
-          sudo boom profile create --from-host --uname-pattern azure
+          sudo boom profile create --from-host --uname-pattern generic --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
+          sudo boom profile create --from-host --uname-pattern azure --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
       - name: Check PyCodestyle
         run: >
           pycodestyle snapm --ignore E501,E203,W503

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -264,6 +264,17 @@ def create_snapset_rollback_entry(snapset, title=None):
     )
 
 
+def _delete_boot_entry(boot_id):
+    """
+    Delete a boom boot entry by ID.
+
+    :param boot_id: The boot identifier to delete.
+    """
+    selection = boom.Selection(boot_id=boot_id)
+    boom.command.delete_entries(selection=selection)
+    boom.cache.clean_cache()
+
+
 def delete_snapset_boot_entry(snapset):
     """
     Delete the boot entry corresponding to ``snapset``.
@@ -272,8 +283,7 @@ def delete_snapset_boot_entry(snapset):
     """
     if snapset.boot_entry is None:
         return
-    selection = boom.Selection(boot_id=snapset.boot_entry.boot_id)
-    boom.command.delete_entries(selection=selection)
+    _delete_boot_entry(snapset.boot_entry.boot_id)
 
 
 def delete_snapset_rollback_entry(snapset):
@@ -284,8 +294,7 @@ def delete_snapset_rollback_entry(snapset):
     """
     if snapset.rollback_entry is None:
         return
-    selection = boom.Selection(boot_id=snapset.rollback_entry.boot_id)
-    boom.command.delete_entries(selection=selection)
+    _delete_boot_entry(boot_id=snapset.rollback_entry.boot_id)
 
 
 class BootEntryCache(dict):

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -19,6 +19,7 @@ from os.path import exists as path_exists
 import logging
 
 import boom
+import boom.cache
 import boom.command
 from boom.bootloader import (
     OPTIONAL_KEYS,
@@ -185,6 +186,7 @@ def _create_boom_boot_entry(
         lvm_root_lv=lvm_root_lv,
         profile=osp,
         write=False,
+        images=boom.command.I_BACKUP,
         no_fstab=True if mounts else False,
         mounts=mounts,
         add_opts=tag_arg,

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -178,6 +178,13 @@ def _create_boom_boot_entry(
                 f"Error calling boom to create default OsProfile: {err}"
             )
 
+    if mounts:
+        add_opts = f"rw {tag_arg}"
+        del_opts = "ro"
+    else:
+        add_opts = tag_arg
+        del_opts = None
+
     entry = boom.command.create_entry(
         title,
         version,
@@ -185,11 +192,12 @@ def _create_boom_boot_entry(
         root_device,
         lvm_root_lv=lvm_root_lv,
         profile=osp,
+        add_opts=add_opts,
+        del_opts=del_opts,
         write=False,
         images=boom.command.I_BACKUP,
         no_fstab=True if mounts else False,
         mounts=mounts,
-        add_opts=tag_arg,
     )
 
     # Apply defaults for optional keys enabled in profile


### PR DESCRIPTION
The systemd-remount-fs service no longer runs if the `fstab=no` kernel command line parameter is present:

```
commit a38de31c8b0dc5a5b1b534e766cb12988a2db5d9
Author: Yu Watanabe <watanabe.yu+github@gmail.com>
Date:   Wed Aug 9 02:02:23 2023 +0900

    remount-fs: refuse to remount based on fstab when fstab=no kernel command line option specified
    
    Otherwise, if for some reasons remount-fs is invoked even when fstab=no is
    specified, mounts may get unexpected options from fstab.
    
    For safety, let's parse the kernel command line option.
```

Ensure that when snapshot manager creates a snapshot boot entry the root file system is set to mount read-write.