### PR TITLE
Use boom's image backup mechanism when creating boot entries

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -37,8 +37,8 @@ jobs:
           sudo mkdir -p /boot/loader/entries
           sudo cp /var/tmp/boom/examples/boom.conf /boot/boom
           # Create profiles for kernel variants seen in CI
-          sudo boom profile create --from-host --uname-pattern generic
-          sudo boom profile create --from-host --uname-pattern azure
+          sudo boom profile create --from-host --uname-pattern generic --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
+          sudo boom profile create --from-host --uname-pattern azure --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
       - name: Check PyCodestyle
         run: >
           pycodestyle snapm --ignore E501,E203,W503

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -264,6 +264,17 @@ def create_snapset_rollback_entry(snapset, title=None):
     )
 
 
+def _delete_boot_entry(boot_id):
+    """
+    Delete a boom boot entry by ID.
+
+    :param boot_id: The boot identifier to delete.
+    """
+    selection = boom.Selection(boot_id=boot_id)
+    boom.command.delete_entries(selection=selection)
+    boom.cache.clean_cache()
+
+
 def delete_snapset_boot_entry(snapset):
     """
     Delete the boot entry corresponding to ``snapset``.
@@ -272,8 +283,7 @@ def delete_snapset_boot_entry(snapset):
     """
     if snapset.boot_entry is None:
         return
-    selection = boom.Selection(boot_id=snapset.boot_entry.boot_id)
-    boom.command.delete_entries(selection=selection)
+    _delete_boot_entry(snapset.boot_entry.boot_id)
 
 
 def delete_snapset_rollback_entry(snapset):
@@ -284,8 +294,7 @@ def delete_snapset_rollback_entry(snapset):
     """
     if snapset.rollback_entry is None:
         return
-    selection = boom.Selection(boot_id=snapset.rollback_entry.boot_id)
-    boom.command.delete_entries(selection=selection)
+    _delete_boot_entry(boot_id=snapset.rollback_entry.boot_id)
 
 
 class BootEntryCache(dict):

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -19,6 +19,7 @@ from os.path import exists as path_exists
 import logging
 
 import boom
+import boom.cache
 import boom.command
 from boom.bootloader import (
     OPTIONAL_KEYS,
@@ -185,6 +186,7 @@ def _create_boom_boot_entry(
         lvm_root_lv=lvm_root_lv,
         profile=osp,
         write=False,
+        images=boom.command.I_BACKUP,
         no_fstab=True if mounts else False,
         mounts=mounts,
         add_opts=tag_arg,


### PR DESCRIPTION
This protects the snapshot entry from the kernel being removed during updates.