### PR TITLE
snapm: rename "rollback" to "revert"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ provisioned snapshots are supported.
                 * [create](#create)
                 * [delete](#delete)
                 * [rename](#rename)
-                * [rollback](#rollback)
+                * [revert](#revert)
                 * [activate](#activate)
                 * [deactivate](#deactivate)
                 * [autoactivate](#autoactivate)
@@ -100,7 +100,7 @@ deactivate, list and display snapsets.
 ##### create
 Create a new snapset with the provided name and list of mount points.
 ```
-# snapm snapset create [-b|--bootable] [-r|--rollback] <name> mount_point...
+# snapm snapset create [-b|--bootable] [-r|--revert] <name> mount_point...
 ```
 ###### Size Policies
 Some snapshot implementations (Lvm2CoW) require a fixed size to be specified
@@ -159,17 +159,17 @@ Rename an existing snapset.
 # snapm snapset rename <old_name> <new_name>
 ```
 
-##### rollback
-Roll back an existing snapset, re-setting the content of the origin volumes
+##### revert
+Revert an existing snapset, re-setting the content of the origin volumes
 to the state they were in at the time the snapset was created. The snapset
-to be rolled back may be specified either by its name or uuid.
+to be reverted may be specified either by its name or uuid.
 
 Rolling back a snapshot set with mounted and in-use origin volumes will
-schedule the roll back to take place the next time that the volumes are
-activated, for example by booting into a configured rollback boot entry for
+schedule the revert to take place the next time that the volumes are
+activated, for example by booting into a configured revert boot entry for
 the snapshot set.
 ```
-# snapm snapset rollback <name|uuid>
+# snapm snapset revert <name|uuid>
 ```
 
 ##### activate
@@ -357,7 +357,7 @@ positional arguments:
 options:
   -h, --help      show this help message and exit
   -b, --bootable  Create a boot entry for this snapshot set
-  -r, --rollback  Create a rollback boot entry for this snapshot set
+  -r, --revert  Create a revert boot entry for this snapshot set
 ```
 
 ## Documentation

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -59,7 +59,7 @@ Snapm \(em Linux snapshot manager
 .  BR snapset
 .  BR \fBcreate
 .  RB [ -b | --bootable ]
-.  RB [ -r | --rollback ]
+.  RB [ -r | --revert ]
 .  RB [ -s | --size-policy
 .  IR policy ]
 .  IR \fIname\fP
@@ -97,10 +97,10 @@ Snapm \(em Linux snapshot manager
 .
 .HP
 .B snapm
-.de CMD_SNAPSET_ROLLBACK
+.de CMD_SNAPSET_REVERT
 .  ad l
 .  BR snapset
-.  BR \fBrollback
+.  BR \fBrevert
 .  IR [ name | uuid ]
 .  RB [ --name
 .  IR name ]
@@ -108,7 +108,7 @@ Snapm \(em Linux snapshot manager
 .  IR uuid ]
 .  ad b
 ..
-.CMD_SNAPSET_ROLLBACK
+.CMD_SNAPSET_REVERT
 .
 .HP
 .B snapm
@@ -370,9 +370,9 @@ Specify which fields to display.
 Specify which fields to sort by.
 .
 .HP
-.BR -r | --rollback
+.BR -r | --revert
 .br
-When creating snapshot sets automatically create a snapshot rollback entry
+When creating snapshot sets automatically create a snapshot revert entry
 for the set.
 .
 .HP
@@ -431,7 +431,7 @@ when creating a snapshot set. The current plugins support LVM2 copy-on-write and
 LVM2 thinly provisioned snapshots.
 
 The \fIsnapset\fP subcommand allows snapsets to be created, deleted,
-enumerated, renamed, rolled back, and activated or deactivated.
+enumerated, renamed, reverted, and activated or deactivated.
 
 The \fIsnapshot\fP subcommand provides access to information describing
 individual snapshots that are part of a snapshot set, for example the device
@@ -508,9 +508,9 @@ UUID:         f217177c-f35a-5b57-b33e-4c8ba0bb231a
 Status:       Inactive
 .br
 
-When creating snapshot sets \fB--bootable\fP and \fB--rollback\fP
+When creating snapshot sets \fB--bootable\fP and \fB--revert\fP
 can optionally be used to automatically create snapshot boot and
-rollback boot entries respectively.
+revert boot entries respectively.
 
 For snapshot providers that require a fixed size snapshot store to be
 allocated (for e.g. lvm2-cow) a size policy can be specified on the create
@@ -554,15 +554,15 @@ Rename an existing snapset. The snapset to be renamed is specified as
 .
 .HP
 .B snapm
-.CMD_SNAPSET_ROLLBACK
+.CMD_SNAPSET_REVERT
 .br
-Roll back an existing snapset, re-setting the content of the origin volumes
+Revert an existing snapset, re-setting the content of the origin volumes
 to the state they were in at the time the snapset was created. The snapset
-to be rolled back may be specified either by its \fBname\fP or \fBuuid\fP.
+to be reverted may be specified either by its \fBname\fP or \fBuuid\fP.
 
 Rolling back a snapshot set with mounted and in-use origin volumes will
-schedule the roll back to take place the next time that the volumes are
-activated, for example by booting into a configured rollback boot entry for
+schedule the revert to take place the next time that the volumes are
+activated, for example by booting into a configured revert boot entry for
 the snapshot set.
 .
 .HP
@@ -700,9 +700,9 @@ Display snapshots matching selection criteria on standard out.
 .
 Snapshot manager integrates with the \fBboom(8)\fP boot manager to facilitate
 booting and rolling back snapshot sets. Specifying the \fB-b|--bootable\fP or
-\fB-r|--rollback\fP arguments when creating a snapshot set will cause
-\fBsnapm\fP to create a snapshot boot or rollback boot entry respectively. In
-order for a snapshot set to be made with boot or rollback support it must
+\fB-r|--revert\fP arguments when creating a snapshot set will cause
+\fBsnapm\fP to create a snapshot boot or revert boot entry respectively. In
+order for a snapshot set to be made with boot or revert support it must
 include a snapshot of the root filesystem.
 
 The snapshot boot entry allows the system to boot into the state of the system
@@ -711,14 +711,14 @@ state of the system or to quickly recover from a failed update or
 reconfiguration.
 
 In order to reset the system back to the state at the time the snapshot set was
-created the rollback boot entry is used \fIafter\fP issuing a \fBsnapm snapset
-rollback\fP command. After running the \fBrollback\fP command the system should
-be rebooted into the rollback boot entry. This will start the rollback
+created the revert boot entry is used \fIafter\fP issuing a \fBsnapm snapset
+revert\fP command. After running the \fBrevert\fP command the system should
+be rebooted into the revert boot entry. This will start the revert
 operation on all affected volumes.
 
 Note that rolling back a snapshot set will also destroy the snapshot set since
 the snapshot volumes are folded back into the origin devices. Following the
-rollback the snapshot set will no longer appear in the output of \fBsnapm
+revert the snapshot set will no longer appear in the output of \fBsnapm
 snapset list\fP or \fBsnapm snapset show\fP commands.
 .
 .SH REPORTING COMMANDS
@@ -758,7 +758,7 @@ Snapshot set Fields
 .br
   bootentry     - Snapshot set boot entry [sha]
 .br
-  rollbackentry - Snapshot set rollback boot entry [sha]
+  revertentry - Snapshot set revert boot entry [sha]
 .br
 .
 .SH REPORT FIELDS
@@ -801,10 +801,10 @@ The autoactivation setting for this snapshot set.
 The \fBboot identifier\fP of the boot loader entry configured to boot this
 snapshot set, or the empty string if no boot entry has been created.
 .TP
-.B rollbackentry
-The \fBboot identifier\fP of the boot loader entry configured to roll back
+.B revertentry
+The \fBboot identifier\fP of the boot loader entry configured to revert
 this snapshot set following a merge operation, or the empty string if no
-rollback boot entry has been created.
+revert boot entry has been created.
 .
 .SS Snapshots
 .
@@ -912,7 +912,7 @@ Status:         Active
 .br
 Boot entry:     b0eb722
 .br
-Rollback entry: c707e9c
+Revert entry: c707e9c
 .br
 .P
 Delete the snapset named 'backup'
@@ -954,7 +954,7 @@ Status:         Active
 .br
 Boot entry:     b0eb722
 .br
-Rollback entry: c707e9c
+Revert entry: c707e9c
 .br
 .P
 Display the snapshot with UUID 96a652ed-1951-569e-86bf-ad2bafcce9d9

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -599,7 +599,7 @@ class SnapshotSet:
         self._snapshots = snapshots
         self._by_mount_point = {}
         self.boot_entry = None
-        self.rollback_entry = None
+        self.revert_entry = None
         for snapshot in self._snapshots:
             self._by_mount_point[snapshot.mount_point] = snapshot
 
@@ -619,8 +619,8 @@ class SnapshotSet:
         )
         if self.boot_entry:
             snapset_str += f"\nBoot entry:     {self.boot_entry.disp_boot_id}"
-        if self.rollback_entry:
-            snapset_str += f"\nRollback entry: {self.rollback_entry.disp_boot_id}"
+        if self.revert_entry:
+            snapset_str += f"\nRevert entry:   {self.revert_entry.disp_boot_id}"
         return snapset_str
 
     @property
@@ -911,15 +911,15 @@ class Snapshot:
             self.name, self.origin, new_name, self.timestamp, self.mount_point
         )
 
-    def rollback(self):
+    def revert(self):
         """
-        Request to roll back a snapshot and revert the content of the origin
+        Request to revert a snapshot and revert the content of the origin
         volume to its state at the time of the snapshot.
 
         This may be deferred until the next device activation or mount
         operation for the respective volume.
         """
-        self._provider.rollback_snapshot(self.name)
+        self._provider.revert_snapshot(self.name)
 
     def invalidate_cache(self):
         """

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -566,13 +566,13 @@ class _Lvm2(Plugin):
             lv_name,
         )
 
-    def rollback_snapshot(self, name):
+    def revert_snapshot(self, name):
         """
-        Roll back the state of the content of the origin to the content at the
+        Revert the state of the content of the origin to the content at the
         time the snapshot was taken.
 
         For LVM2 snapshots of in-use logical volumes this will take place at
-        the next activation (typically a reboot into the rollback boot entry
+        the next activation (typically a reboot into the revert boot entry
         for the snapshot set).
         """
         lvconvert_cmd = [

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -155,17 +155,17 @@ class BootTests(unittest.TestCase):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.create_snapshot_set_boot_entry()
 
-    def test_create_snapshot_rollback_entry_no_id(self):
+    def test_create_snapshot_revert_entry_no_id(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
-            self.manager.create_snapshot_set_rollback_entry()
+            self.manager.create_snapshot_set_revert_entry()
 
     def test_create_snapshot_boot_entry_bad_name(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.create_snapshot_set_boot_entry(name="bootset1")
 
-    def test_create_snapshot_rollback_entry_bad_name(self):
+    def test_create_snapshot_revert_entry_bad_name(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
-            self.manager.create_snapshot_set_rollback_entry(name="bootset1")
+            self.manager.create_snapshot_set_revert_entry(name="bootset1")
 
     def test_create_snapshot_boot_entry(self):
         self.manager.create_snapshot_set_boot_entry(name="bootset0")
@@ -173,10 +173,10 @@ class BootTests(unittest.TestCase):
         # Clean up boot entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
-    def test_create_snapshot_rollback_entry(self):
-        self.manager.create_snapshot_set_rollback_entry(name="bootset0")
+    def test_create_snapshot_revert_entry(self):
+        self.manager.create_snapshot_set_revert_entry(name="bootset0")
 
-        # Clean up rollback entry
+        # Clean up revert entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
     def test_create_snapshot_boot_entry_bad_uuid(self):
@@ -185,9 +185,9 @@ class BootTests(unittest.TestCase):
                 uuid="00000000-0000-0000-0000-000000000000"
             )
 
-    def test_create_snapshot_rollback_entry_bad_uuid(self):
+    def test_create_snapshot_revert_entry_bad_uuid(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
-            self.manager.create_snapshot_set_rollback_entry(
+            self.manager.create_snapshot_set_revert_entry(
                 uuid="00000000-0000-0000-0000-000000000000"
             )
 
@@ -198,17 +198,17 @@ class BootTests(unittest.TestCase):
         # Clean up boot entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
-    def test_create_snapshot_rollback_entry_uuid(self):
+    def test_create_snapshot_revert_entry_uuid(self):
         sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
-        self.manager.create_snapshot_set_rollback_entry(uuid=str(sset.uuid))
+        self.manager.create_snapshot_set_revert_entry(uuid=str(sset.uuid))
 
-        # Clean up rollback entry
+        # Clean up revert entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
     def test_create_boot_entries_and_discovery(self):
         sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
         self.manager.create_snapshot_set_boot_entry(name="bootset0")
-        self.manager.create_snapshot_set_rollback_entry(name="bootset0")
+        self.manager.create_snapshot_set_revert_entry(name="bootset0")
 
         # Re-discover snapshot sets w/attached boot entries
         self.manager.discover_snapshot_sets()
@@ -219,10 +219,10 @@ class BootTests(unittest.TestCase):
         for snapshot in sset.snapshots:
             self.assertIn(snapshot.devpath, boot_entry.options)
 
-        # Validate roll back entry
-        rollback_entry = sset.rollback_entry
+        # Validate revert entry
+        revert_entry = sset.revert_entry
         root_snapshot = sset.snapshot_by_mount_point("/")
-        self.assertIn(root_snapshot.origin, rollback_entry.options)
+        self.assertIn(root_snapshot.origin, revert_entry.options)
 
         # Clean up boot entries
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -89,12 +89,17 @@ class BootTests(unittest.TestCase):
         os.unlink(TMP_FSTAB)
 
     def _populate_boom_root_path(self):
+        """
+        Populate a mock /boot directory for testing.
+        """
         boot_dir = tempfile.mkdtemp("_snapm_boom_dir", dir=_VAR_TMP)
         boom_dir = os.path.join(boot_dir, "boom")
         os.makedirs(os.path.join(boot_dir, "loader", "entries"), exist_ok=True)
+
         subdirs = ["cache", "hosts", "profiles"]
         for subdir in subdirs:
             os.makedirs(os.path.join(boom_dir, subdir), exist_ok=True)
+
         boom_conf = [
             "[global]\n",
             f"boot_root = {boot_dir}\n",
@@ -106,6 +111,18 @@ class BootTests(unittest.TestCase):
         ]
         with open(os.path.join(boom_dir, "boom.conf"), "w", encoding="utf8") as file:
             file.writelines(boom_conf)
+
+        # Create fake kernel and initramfs for current uname -r
+        version = os.uname()[2]
+        with open(
+            os.path.join(boot_dir, f"vmlinuz-{version}"), "w", encoding="utf8"
+        ) as file:
+            file.write("test\n")
+        with open(
+            os.path.join(boot_dir, f"initramfs-{version}.img"), "w", encoding="utf8"
+        ) as file:
+            file.write("test\n")
+
         return boot_dir
 
     def _cleanup_boom_root_path(self, boot_path):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -420,7 +420,7 @@ class CommandTests(unittest.TestCase):
         ]
         self.assertEqual(command.main(args), 0)
 
-    def test_main_snapset_rollback(self):
+    def test_main_snapset_revert(self):
         origin_file = "root/origin"
         snapshot_file = "root/snapshot"
         testset = "testset0"
@@ -434,8 +434,8 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(self._lvm.test_path(origin_file), True)
         self.assertEqual(self._lvm.test_path(snapshot_file), True)
 
-        # Start roll back the snapshot set
-        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "rollback", testset]
+        # Start revert the snapshot set
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "revert", testset]
         self.assertEqual(command.main(args), 0)
 
         # Unmount the set, deactivate/reactivate and re-mount

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -378,7 +378,7 @@ class ManagerTests(unittest.TestCase):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.set_autoactivate(s, True)
 
-    def test_rollback_snapshot_sets(self):
+    def test_revert_snapshot_sets(self):
         origin_file = "root/origin"
         snapshot_file = "root/snapshot"
         testset = "testset0"
@@ -392,9 +392,9 @@ class ManagerTests(unittest.TestCase):
         self.assertEqual(self._lvm.test_path(origin_file), True)
         self.assertEqual(self._lvm.test_path(snapshot_file), True)
 
-        # Start roll back the snapshot set
+        # Start revert the snapshot set
         selection = snapm.Selection(name=testset)
-        self.manager.rollback_snapshot_sets(selection)
+        self.manager.revert_snapshot_sets(selection)
 
         # Unmount the set, deactivate/reactivate and re-mount
         self._lvm.umount_all()


### PR DESCRIPTION
The existing linux-system-roles snapshot role refers to the operation as "revert". Rename the snapshot manager operation to be more consistent.