### PR TITLE
Warn user to reboot when reverting a snapset with in-use origin devices

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -21,6 +21,7 @@ import json
 import math
 import logging
 import re
+import os
 
 _log = logging.getLogger(__name__)
 
@@ -785,6 +786,18 @@ class SnapshotSet:
                     err,
                 )
 
+    @property
+    def origin_mounted(self):
+        """
+        Test whether the origin volumes for this ``SnapshotSet`` are currently
+        mounted and in use.
+
+        :returns: ``True`` if any of the snaphots belonging to this
+                  ``SnapshotSet`` are currently mounted, or ``False``
+                  otherwise.
+        """
+        return any([s.origin_mounted for s in self.snapshots])
+
     def snapshot_by_mount_point(self, mount_point):
         """
         Return the snapshot corresponding to ``mount_point``.
@@ -994,6 +1007,22 @@ class Snapshot:
         snapshot is automatically activated or ``False`` otherwise.
         """
         raise NotImplementedError
+
+    @property
+    def origin_mounted(self):
+        """
+        Test whether the origin volume for this ``Snapshot`` is currently
+        mounted and in use.
+
+        :returns: ``True`` if this snaphot's prigin is currently mounted
+                  or ``False`` otherwise.
+        """
+        with open("/proc/mounts") as mounts:
+            for line in mounts:
+                fields = line.split(" ")
+                if self.mount_point == fields[1]:
+                    return os.path.samefile(self.origin, fields[0])
+        return False
 
     def delete(self):
         """

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -648,7 +648,7 @@ class SnapshotSet:
             f"{SNAPSET_TIME}:             {datetime.fromtimestamp(self.timestamp)}\n"
             f"{SNAPSET_UUID}:             {self.uuid}\n"
             f"{SNAPSET_STATUS}:           {str(self.status)}\n"
-            f"{SNAPSET_AUTOACTIVATE}:     {'yes' if self.autoactivate else 'no'}"
+            f"{SNAPSET_AUTOACTIVATE}:     {'yes' if self.autoactivate else 'no'}\n"
         )
         if self.boot_entry or self.revert_entry:
             snapset_str += f"\n{SNAPSET_BOOT_ENTRIES}:"
@@ -674,6 +674,7 @@ class SnapshotSet:
         pmap[SNAPSET_TIME] = self.time
         pmap[SNAPSET_UUID] = str(self.uuid)
         pmap[SNAPSET_STATUS] = str(self.status)
+        pmap[SNAPSET_AUTOACTIVATE] = self.autoactivate
 
         if self.boot_entry or self.revert_entry:
             pmap[SNAPSET_BOOT_ENTRIES] = {}

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -198,6 +198,13 @@ class SnapmExistsError(SnapmError):
     """
 
 
+class SnapmBusyError(SnapmError):
+    """
+    A resouce needed by the current command is already in use: for e.g.
+    a snapshot merge is in progress for a previous snapshot set.
+    """
+
+
 class SnapmPathError(SnapmError):
     """
     An invalid path was supplied, for example attempting to snapshot
@@ -1124,6 +1131,7 @@ __all__ = [
     "SnapmNoSpaceError",
     "SnapmNoProviderError",
     "SnapmExistsError",
+    "SnapmBusyError",
     "SnapmPathError",
     "SnapmNotFoundError",
     "SnapmInvalidIdentifierError",

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -74,6 +74,7 @@ SNAPSET_TIMESTAMP = "Timestamp"
 SNAPSET_UUID = "UUID"
 SNAPSET_STATUS = "Status"
 SNAPSET_AUTOACTIVATE = "Autoactivate"
+SNAPSET_BOOTABLE = "Bootable"
 SNAPSET_BOOT_ENTRIES = "BootEntries"
 SNAPSET_SNAPSHOT_ENTRY = "SnapshotEntry"
 SNAPSET_REVERT_ENTRY = "RevertEntry"
@@ -649,6 +650,7 @@ class SnapshotSet:
             f"{SNAPSET_UUID}:             {self.uuid}\n"
             f"{SNAPSET_STATUS}:           {str(self.status)}\n"
             f"{SNAPSET_AUTOACTIVATE}:     {'yes' if self.autoactivate else 'no'}\n"
+            f"{SNAPSET_BOOTABLE}:         {'yes' if self.boot_entry is not None else 'no'}"
         )
         if self.boot_entry or self.revert_entry:
             snapset_str += f"\n{SNAPSET_BOOT_ENTRIES}:"
@@ -675,6 +677,7 @@ class SnapshotSet:
         pmap[SNAPSET_UUID] = str(self.uuid)
         pmap[SNAPSET_STATUS] = str(self.status)
         pmap[SNAPSET_AUTOACTIVATE] = self.autoactivate
+        pmap[SNAPSET_BOOTABLE] = self.boot_entry is not None
 
         if self.boot_entry or self.revert_entry:
             pmap[SNAPSET_BOOT_ENTRIES] = {}
@@ -1091,6 +1094,7 @@ __all__ = [
     "SNAPSET_UUID",
     "SNAPSET_STATUS",
     "SNAPSET_AUTOACTIVATE",
+    "SNAPSET_BOOTABLE",
     "SNAPSET_BOOT_ENTRIES",
     "SNAPSET_SNAPSHOT_ENTRY",
     "SNAPSET_REVERT_ENTRY",

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -35,6 +35,7 @@ from snapm import (
     SNAPSET_UUID,
     SNAPSET_STATUS,
     SNAPSET_AUTOACTIVATE,
+    SNAPSET_BOOTABLE,
     SNAPSET_BOOT_ENTRIES,
     SNAPSET_SNAPSHOT_ENTRY,
     SNAPSET_REVERT_ENTRY,
@@ -203,6 +204,15 @@ _snapshot_set_fields = [
         12,
         REP_STR,
         lambda f, d: f.report_str(_bool_to_yes_no(d.autoactivate)),
+    ),
+    FieldType(
+        PR_SNAPSET,
+        "bootable",
+        SNAPSET_BOOTABLE,
+        "Configured for snapshot boot",
+        8,
+        REP_STR,
+        lambda f, d: f.report_str(_bool_to_yes_no(d.boot_entry is not None)),
     ),
     FieldType(
         PR_SNAPSET,

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -677,19 +677,19 @@ class Manager:
                 new_snapshots.append(new_snapshot)
             except SnapmError as err:
                 _log_error("Failed to rename snapshot %s: %s", snapshot.name, err)
-                revert_snapshots = []
+                rollback_snapshots = []
                 for new_snapshot in new_snapshots:
                     try:
-                        revert_snapshot = snapshot.rename(old_name)
-                        revert_snapshots.append(revert_snapshot)
+                        rollback_snapshot = snapshot.rename(old_name)
+                        rollback_snapshots.append(rollback_snapshot)
                     except SnapmError as err2:
                         _log_error(
-                            "Failed to revert snapshot rename on %s: %s",
+                            "Failed to rollback snapshot rename on %s: %s",
                             snapshot.name,
                             err2,
                         )
                 old_snapset = SnapshotSet(
-                    old_name, timestamp, snapshots + revert_snapshots
+                    old_name, timestamp, snapshots + rollback_snapshots
                 )
                 self.by_name[old_snapset.name] = old_snapset
                 self.by_uuid[str(old_snapset.uuid)] = old_snapset

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -770,6 +770,16 @@ class Manager:
                     raise SnapmPluginError(
                         f"Could not revert all snapshots for set {snapset.name}"
                     )
+            if snapset.origin_mounted:
+                _log_warn(
+                    "Snaphot set %s origin is in use: reboot required to complete revert",
+                    snapset.name,
+                )
+                if snapset.revert_entry:
+                    _log_warn(
+                        "Boot into '%s' to continue",
+                        snapset.revert_entry.title,
+                    )
             reverted += 1
         self._boot_cache.refresh_cache()
         return reverted

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -25,6 +25,7 @@ from snapm import (
     SNAPM_DEBUG_PLUGINS,
     SnapmInvalidIdentifierError,
     SnapmCalloutError,
+    SnapmBusyError,
     SnapmNoSpaceError,
     SizePolicy,
     SnapStatus,
@@ -82,6 +83,7 @@ LVM_COW_ORIGIN_ATTR = "o"
 LVM_ACTIVE_ATTR = "a"
 LVM_INVALID_ATTR = "I"
 LVM_LV_TYPE_DEFAULT = "-"
+LVM_LV_ORIGIN_MERGING = "O"
 LVM_SKIP_ACTIVATION_ATTR = "k"
 
 # lv_attr flag indexes
@@ -711,6 +713,10 @@ class Lvm2Cow(_Lvm2):
         lvs_dict = get_lvs_json_report(f"{vg_name}/{lv_name}")
         lv_report = lvs_dict[LVS_REPORT][0][LVS_LV][0]
         lv_attr = lv_report[LVS_LV_ATTR]
+        if lv_attr[0] == LVM_LV_ORIGIN_MERGING:
+            raise SnapmBusyError(
+                f"Snapshot revert is in progress for {vg_name}/{lv_name}"
+            )
         if lv_attr[0] != LVM_LV_TYPE_DEFAULT and lv_attr[0] != LVM_COW_ORIGIN_ATTR:
             return False
         return True
@@ -849,6 +855,10 @@ class Lvm2Thin(_Lvm2):
         lvs_dict = get_lvs_json_report(f"{vg_name}/{lv_name}")
         lv_report = lvs_dict[LVS_REPORT][0][LVS_LV][0]
         lv_attr = lv_report[LVS_LV_ATTR]
+        if lv_attr[0] == LVM_LV_ORIGIN_MERGING:
+            raise SnapmBusyError(
+                f"Snapshot revert is in progress for {vg_name}/{lv_name}"
+            )
         if lv_attr[0] != LVM_THIN_VOL_ATTR:
             return False
         return True


### PR DESCRIPTION
Revert operations require a reboot to take effect when the origin volumes are in use. Detect this in Manager.revert_snapshot_sets() and warn the user.
