### PR TITLE
snapm: add 'plugin' subcommand to display info on available plugins

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -19,6 +19,12 @@
 .de ARG_SNAPSHOT_COMMANDS
 .  RI [ activate | deactivate | autoactivate | list | show ]
 ..
+.de ARG_PLUGIN_TYPE
+.  RI plugin
+..
+.de ARG_PLUGIN_COMMANDS
+.  RI [ list ]
+..
 .
 ..
 .SH NAME
@@ -52,6 +58,17 @@ Snapm \(em Linux snapshot manager
 .CMD_SNAPSHOT_COMMAND
 
 .
+.HP
+.B snapm
+.de CMD_PLUGIN_COMMAND
+.  ad l
+.  ARG_GLOBAL
+.  ARG_PLUGIN_TYPE
+.  ARG_PLUGIN_COMMANDS
+.  ad b
+..
+.CMD_PLUGIN_COMMAND
+
 .HP
 .B snapm
 .de CMD_SNAPSET_CREATE
@@ -299,6 +316,24 @@ Snapm \(em Linux snapshot manager
 .  ad b
 ..
 .CMD_SNAPSHOT_SHOW
+.
+.HP
+.B snapm
+.de CMD_PLUGIN_LIST
+.  BR plugin
+.  BR \fBlist
+.  RB [ --nameprefixes ]
+.  RB [ --noheadings ]
+.  RB [ --options
+.  IR fields ]
+.  RB [ --sort
+.  IR fields ]
+.  RB [ --rows ]
+.  RB [ --separator
+.  IR separator ]
+.  ad b
+..
+.CMD_PLUGIN_LIST
 
 .
 .PD
@@ -713,6 +748,34 @@ that field respectively.
 .CMD_SNAPSHOT_SHOW
 .br
 Display snapshots matching selection criteria on standard out.
+.
+.P
+.B Plugin Commands
+.P
+.
+.HP
+.B snapm
+.CMD_PLUGIN_LIST
+.br
+Output a tabular report of plugins.
+
+Displays a report with one plugin per line, containing fields describing the
+properties of the available plugins.
+
+The list of fields to display is given with \fB--options\fP as a comma separated
+list of field names. To obtain a list of available fields run '\fBsnapm plugin
+list -o help\fP'. If the list of fields begins with the '\fB+\fP' character the
+specified fields are appended to the default field list. Otherwise the given
+list of fields replaces the default set of report fields.
+
+The \fB--rows\fP, \fB--noheadings\fP, and \fB--nameprefixes\fP options can be
+used to generate output in a machine readable form, suitable for setting shell
+or environment variables.
+
+Report output may be sorted by multiple user-defined keys using the \fB--sort\fP
+option. The option expects a comma separated list of keys, with optional
+\fB+\fP and \fB-\fP prefixes indicating ascending and descending sort for
+that field respectively.
 .
 .SH BOOTING AND ROLLING BACK SNAPSHOT SETS
 .

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -816,7 +816,7 @@ def _show_cmd(cmd_args):
     return 0
 
 
-def _activate_snapshot_cmd(cmd_args):
+def _snapshot_activate_cmd(cmd_args):
     """
     Activate snapshot command handler.
 
@@ -840,7 +840,7 @@ def _activate_snapshot_cmd(cmd_args):
     return 0
 
 
-def _deactivate_snapshot_cmd(cmd_args):
+def _snapshot_deactivate_cmd(cmd_args):
     """
     Deactivate snapshot command handler.
 
@@ -864,7 +864,7 @@ def _deactivate_snapshot_cmd(cmd_args):
     return 0
 
 
-def _autoactivate_snapshot_cmd(cmd_args):
+def _snapshot_autoactivate_cmd(cmd_args):
     """
     Autoactivate snapshot command handler.
 
@@ -889,7 +889,7 @@ def _autoactivate_snapshot_cmd(cmd_args):
     return 0
 
 
-def _list_snapshot_cmd(cmd_args):
+def _snapshot_list_cmd(cmd_args):
     """
     List snapshots command handler.
 
@@ -905,7 +905,7 @@ def _list_snapshot_cmd(cmd_args):
     return _generic_list_cmd(cmd_args, select, opts, manager, print_snapshots)
 
 
-def _show_snapshot_cmd(cmd_args):
+def _snapshot_show_cmd(cmd_args):
     """
     Show snapshots command handler.
 
@@ -1269,20 +1269,20 @@ def main(args):
         ACTIVATE_CMD, help="Activate snapshots"
     )
     _add_identifier_args(snapshot_activate_parser, snapset=True, snapshot=True)
-    snapshot_activate_parser.set_defaults(func=_activate_snapshot_cmd)
+    snapshot_activate_parser.set_defaults(func=_snapshot_activate_cmd)
 
     # snapshot deactivate subcommand
     snapshot_deactivate_parser = snapshot_subparser.add_parser(
         DEACTIVATE_CMD, help="Deactivate snapshots"
     )
     _add_identifier_args(snapshot_deactivate_parser, snapset=True, snapshot=True)
-    snapshot_deactivate_parser.set_defaults(func=_deactivate_snapshot_cmd)
+    snapshot_deactivate_parser.set_defaults(func=_snapshot_deactivate_cmd)
 
     # snapshot autoactivate command
     snapshot_autoactivate_parser = snapshot_subparser.add_parser(
         AUTOACTIVATE_CMD, help="Set autoactivation status for snapshots"
     )
-    snapshot_autoactivate_parser.set_defaults(func=_autoactivate_snapshot_cmd)
+    snapshot_autoactivate_parser.set_defaults(func=_snapshot_autoactivate_cmd)
     _add_identifier_args(snapshot_autoactivate_parser, snapset=True, snapshot=True)
     _add_autoactivate_args(snapshot_autoactivate_parser)
 
@@ -1290,7 +1290,7 @@ def main(args):
     snapshot_list_parser = snapshot_subparser.add_parser(
         LIST_CMD, help="List snapshots"
     )
-    snapshot_list_parser.set_defaults(func=_list_snapshot_cmd)
+    snapshot_list_parser.set_defaults(func=_snapshot_list_cmd)
     _add_report_args(snapshot_list_parser)
     _add_identifier_args(snapshot_list_parser, snapset=True, snapshot=True)
 
@@ -1298,7 +1298,7 @@ def main(args):
     snapshot_show_parser = snapshot_subparser.add_parser(
         SHOW_CMD, help="Display snapshots"
     )
-    snapshot_show_parser.set_defaults(func=_show_snapshot_cmd)
+    snapshot_show_parser.set_defaults(func=_snapshot_show_cmd)
     _add_identifier_args(snapshot_show_parser, snapset=True, snapshot=True)
     _add_json_arg(snapshot_show_parser)
 

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -45,6 +45,7 @@ from snapm import (
     Selection,
     is_size_policy,
     SnapshotSet,
+    Snapshot,
 )
 
 
@@ -78,6 +79,7 @@ class Plugin(metaclass=PluginRegistry):
 
     name = "plugin"
     version = "0.1.0"
+    snapshot_class = Snapshot
 
     def __init__(self):
         self.size_map = None

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -648,6 +648,7 @@ class Lvm2Cow(_Lvm2):
 
     name = "lvm2-cow"
     version = "0.1.0"
+    snapshot_class = Lvm2CowSnapshot
 
     def discover_snapshots(self):
         """
@@ -818,6 +819,7 @@ class Lvm2Thin(_Lvm2):
 
     name = "lvm2-thin"
     version = "0.1.0"
+    snapshot_class = Lvm2ThinSnapshot
 
     def discover_snapshots(self):
         snapshots = []

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -154,6 +154,14 @@ class CommandTestsSimple(unittest.TestCase):
         args = MockArgs()
         command._snapshot_show_cmd(args)
 
+    def test__plugin_list_cmd_simple(self):
+        args = MockArgs()
+        command._plugin_list_cmd(args)
+
+    def test_main_plugin_list(self):
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "plugin", "list"]
+        self.assertEqual(command.main(args), 0)
+
     def test_set_debug_none(self):
         args = MockArgs()
         command.set_debug(args.debug)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -139,7 +139,7 @@ class CommandTestsSimple(unittest.TestCase):
 
     def test__list_snapshot_cmd_simple(self):
         args = MockArgs()
-        command._list_snapshot_cmd(args)
+        command._snapshot_list_cmd(args)
 
     def test__show_cmd_simple(self):
         args = MockArgs()
@@ -152,7 +152,7 @@ class CommandTestsSimple(unittest.TestCase):
 
     def test__show_snapshot_cmd_simple(self):
         args = MockArgs()
-        command._show_snapshot_cmd(args)
+        command._snapshot_show_cmd(args)
 
     def test_set_debug_none(self):
         args = MockArgs()


### PR DESCRIPTION
Add a new 'snapm plugin list' command to display the available plugins:
    
```
root@localhost:~/src/git/snapm# snapm plugin list
PluginName PluginVersion PluginType
lvm2-cow   0.1.0         Lvm2CowSnapshot
lvm2-thin  0.1.0         Lvm2ThinSnapshot
```