### PR TITLE
Prepare for pip builds and publishing on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the available options and commands.
 The `snapm` command uses the [boom boot manager][5] to manage boot entries for
 the snapshots that it creates. If installing `snapm` manually, Install `boom`
 first: either from your distribution repositories or the upstream Git repo.
-Snapshot manager is tested with boom-1.6.0 and later.
+Snapshot manager is tested with boom-1.6.4 and later.
 
 ### Building an RPM package
 A spec file is included in the repository that can be used to build RPM packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "snapm"
+version = "0.2.1"
+license = { file="COPYING" }
+authors = [
+  { name="Bryn M. Reeves", email="bmr@redhat.com" },
+]
+description = "Snapshot Manager"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+dependencies = [
+    "boom-boot >= 1.6.4",
+]
+
+[project.urls]
+Homepage = "https://github.com/snapshotmanager/snapm"
+Issues = "https://github.com/snapshotmanager/snapm/issues"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pycodestyle>=2.4.0
 coverage>=4.0.3
 Sphinx>=1.3.5
+boom-boot>=1.6.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ classifiers =
 [options]
 packages = find:
 scripts = bin/snapm
+install_requires =
+    boom-boot >= 1.6.4
 
 [options.packages.find]
 exclude =

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -30,6 +30,7 @@ from snapm.manager.boot import (
     delete_snapset_boot_entry,
     create_snapset_revert_entry,
     delete_snapset_revert_entry,
+    check_boom_config,
 )
 
 from snapm import (
@@ -420,6 +421,7 @@ class Manager:
         self.snapshot_sets = []
         self.by_name = {}
         self.by_uuid = {}
+        check_boom_config()
         self._boot_cache = BootCache()
         load_plugins()
         for plugin_class in PluginRegistry.plugins:

--- a/snapm/manager/boot.py
+++ b/snapm/manager/boot.py
@@ -21,6 +21,7 @@ import logging
 import boom
 import boom.cache
 import boom.command
+from boom.config import load_boom_config
 from boom.bootloader import (
     OPTIONAL_KEYS,
     optional_key_default,
@@ -307,6 +308,17 @@ def delete_snapset_revert_entry(snapset):
     if snapset.revert_entry is None:
         return
     _delete_boot_entry(boot_id=snapset.revert_entry.boot_id)
+
+
+def check_boom_config():
+    """
+    Check for boom configuration and create the default config if not found.
+    """
+    try:
+        load_boom_config()
+    except ValueError as e:
+        _log_info("No boom configuration found: generating default config in /boot")
+        boom.command.create_config()
 
 
 class BootEntryCache(dict):

--- a/tests/boot/boom/boom.conf
+++ b/tests/boot/boom/boom.conf
@@ -1,5 +1,5 @@
 [global]
-boot_root = tests
+boot_root = tests/boot
 boom_root = %(boot_root)s/boom
 
 [legacy]


### PR DESCRIPTION
dist: add dependency on boom-boot >= 1.6.0
This dependency can't currently be met - boom needs to be published on PyPi first.