### PR TITLE
dist: add boom-boot to RPM Recommends

### DIFF
--- a/snapm.spec
+++ b/snapm.spec
@@ -22,6 +22,7 @@ BuildRequires:  boom-boot
 
 Requires: python3-snapm = %{version}-%{release}
 Requires: python3-boom
+Recommends: boom-boot
 
 %package -n python3-snapm
 Summary: %{summary}
@@ -82,6 +83,7 @@ rm doc/conf.py
 
 %changelog
 * Thu Jun 20 2023 Bryn M. Reeves <bmr@redhat.com> - 0.3.0
+- dist: add boom-boot to RPM Recommends
 - snapm: forbid revert if snapset status is SnapStatus.INVALID
 - dist: add pyproject.toml
 - tests: fix boot path in tests/boot/boom/boom.conf


### PR DESCRIPTION
Add `boom-boot` to the Recommends weak dependency for the `snapm` package. This will cause RPM depsolvers to install the `boom-boot` package by default if available when installing `snapm`. This is needed for the `boom` command line tool that users will need to clean up Revert boot entries after rolling back a snapshot set with `snapm snapset revert <name>`.