### PR TITLE
snapm: generalise revert check for mounted fs to snapshot and origin

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -814,6 +814,30 @@ class SnapshotSet:
         """
         return any([s.origin_mounted for s in self.snapshots])
 
+    @property
+    def snapshot_mounted(self):
+        """
+        Test whether the snapshot volumes for this ``SnapshotSet`` are currently
+        mounted and in use.
+
+        :returns: ``True`` if any of the snaphots belonging to this
+                  ``SnapshotSet`` are currently mounted, or ``False``
+                  otherwise.
+        """
+        return any([s.snapshot_mounted for s in self.snapshots])
+
+    @property
+    def mounted(self):
+        """
+        Test whether the either the origin or snapshot volumes for this
+        ``SnapshotSet`` are currently mounted and in use.
+
+        :returns: ``True`` if any of the snaphots belonging to this
+                  ``SnapshotSet`` are currently mounted, or ``False``
+                  otherwise.
+        """
+        return self.snapshot_mounted or self.origin_mounted
+
     def snapshot_by_mount_point(self, mount_point):
         """
         Return the snapshot corresponding to ``mount_point``.
@@ -1039,6 +1063,35 @@ class Snapshot:
                 if self.mount_point == fields[1]:
                     return os.path.samefile(self.origin, fields[0])
         return False
+
+    @property
+    def snapshot_mounted(self):
+        """
+        Test whether the snapshot volume for this ``Snapshot`` is currently
+        mounted and in use.
+
+        :returns: ``True`` if this snaphot is currently mounted or ``False``
+                  otherwise.
+        """
+        if self.status != SnapStatus.ACTIVE:
+            return False
+        with open("/proc/mounts") as mounts:
+            for line in mounts:
+                fields = line.split(" ")
+                if self.mount_point == fields[1]:
+                    return os.path.samefile(self.devpath, fields[0])
+        return False
+
+    @property
+    def mounted(self):
+        """
+        Test whether either the snapshot or origin volume for this ``Snapshot``
+        is currently mounted and in use.
+
+        :returns: ``True`` if this snapshot or its origin is currently mounted
+                  or ``False`` otherwise.
+        """
+        return self.snapshot_mounted or self.origin_mounted
 
     def delete(self):
         """

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -795,7 +795,7 @@ def _revert_cmd(cmd_args):
         raise SnapmInvalidIdentifierError("Revert requires a snapset name or UUID")
 
     snapset = revert_snapset(manager, name=name, uuid=uuid)
-    if snapset.origin_mounted and snapset.revert_entry:
+    if snapset.mounted and snapset.revert_entry:
         print(f"Boot into '{snapset.revert_entry.title}' to continue")
     _log_info("Started revert for snapset %s", snapset.name)
     return 0

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -795,9 +795,9 @@ class Manager:
                 raise SnapmPluginError(
                     f"Could not revert all snapshots for set {snapset.name}"
                 )
-        if snapset.origin_mounted:
+        if snapset.mounted:
             _log_warn(
-                "Snaphot set %s origin is in use: reboot required to complete revert",
+                "Snaphot set %s is in use: reboot required to complete revert",
                 snapset.name,
             )
 


### PR DESCRIPTION
The snapshot is considered "in use" for revert purposes if either the snapshot or the origin is currently mounted and in use. Add snapshot_mounted properties to Snapshot and SnapshotSet and a new mounted property which is True when either the snapshot or its origin is in use.

Test SnapshotSet.mounted in snapm.manager and snapm.command when determining whether a to-be-reverted snapshot set is in use or not.

Resolves: #61