### PR TITLE
Improve coverage of snapm.manager.plugins

### DIFF
--- a/snapm/manager/plugins/_plugin.py
+++ b/snapm/manager/plugins/_plugin.py
@@ -216,7 +216,7 @@ def device_from_mount_point(mount_point):
             (device, mount_path) = _parse_proc_mounts_line(line)
             if mount_path == mount_point:
                 return device
-    raise ValueError(f"Mount point {mount_point} not found")
+    raise KeyError(f"Mount point {mount_point} not found")
 
 
 def mount_point_space_used(mount_point):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,6 +46,16 @@ class PluginTests(unittest.TestCase):
                 snapshot_names[snapshot_name],
             )
 
+    def test_parse_snapshot_name_none(self):
+        snapshot_names = {
+            "some_snapshot_volume": "origin_volume",
+            "somesnapshot": "some",
+            "some_snapshot": "some",
+            "root-notsnapset_backup_1693921253_-": "root",
+        }
+        for name, origin in snapshot_names.items():
+            self.assertEqual(None, plugins.parse_snapshot_name(name, origin))
+
     def test_encode_mount_point(self):
         mounts = {
             "/": "-",
@@ -56,6 +66,7 @@ class PluginTests(unittest.TestCase):
             "/var/foo-bar": "-var-foo--bar",
             "/foo_bar": "-foo_bar",
             "/data:storage": "-data.3astorage",
+            "/data.storage": "-data..storage",
         }
         for mount in mounts.keys():
             self.assertEqual(plugins.encode_mount_point(mount), mounts[mount])
@@ -70,6 +81,7 @@ class PluginTests(unittest.TestCase):
             "-var-foo--bar": "/var/foo-bar",
             "-foo_bar": "/foo_bar",
             "-data.3astorage": "/data:storage",
+            "-data..storage" : "/data.storage",
         }
         for enc_mount in enc_mounts.keys():
             self.assertEqual(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -55,6 +55,7 @@ class PluginTests(unittest.TestCase):
             "/var/tmp": "-var-tmp",
             "/var/foo-bar": "-var-foo--bar",
             "/foo_bar": "-foo_bar",
+            "/data:storage": "-data.3astorage",
         }
         for mount in mounts.keys():
             self.assertEqual(plugins.encode_mount_point(mount), mounts[mount])
@@ -68,6 +69,7 @@ class PluginTests(unittest.TestCase):
             "-var-tmp": "/var/tmp",
             "-var-foo--bar": "/var/foo-bar",
             "-foo_bar": "/foo_bar",
+            "-data.3astorage": "/data:storage",
         }
         for enc_mount in enc_mounts.keys():
             self.assertEqual(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -81,6 +81,10 @@ class PluginTests(unittest.TestCase):
         with self.assertRaises(KeyError) as cm:
             dev = plugins.device_from_mount_point("/quuxfoo")
 
+    def test_mount_point_space_used(self):
+        used = plugins.mount_point_space_used("/sys")
+        self.assertEqual(0, used)
+
     def test_encode_mount_point(self):
         mounts = {
             "/": "-",


### PR DESCRIPTION
Coverage is a bit low for `snapm.manager.plugins`:

```
snapm/manager/plugins/_plugin.py                            102     13    87%
```

This is all fairly easy to test so increase the coverage of the helper functions in this package.