### PR TITLE
snapm: validate UUIDs during argument parsing

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -355,21 +355,14 @@ class Selection:
         snapshot_uuid = None
         if cmd_args.identifier:
             try:
-                UUID(cmd_args.identifier)
-                uuid = cmd_args.identifier
+                uuid = UUID(cmd_args.identifier)
             except (TypeError, ValueError):
                 name = cmd_args.identifier
         else:
             if cmd_args.name:
                 name = cmd_args.name
             elif cmd_args.uuid:
-                try:
-                    UUID(cmd_args.uuid)
-                    uuid = cmd_args.uuid
-                except (TypeError, ValueError) as err:
-                    raise SnapmInvalidIdentifierError(
-                        f"Invalid UUID: '{cmd_args.uuid}'"
-                    ) from err
+                uuid = cmd_args.uuid
 
         if hasattr(cmd_args, "snapshot_name"):
             snapshot_name = cmd_args.snapshot_name

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -23,6 +23,7 @@ in the snapm object API.
 from argparse import ArgumentParser
 from os.path import basename
 from json import dumps
+from uuid import UUID
 import logging
 
 from snapm import (
@@ -1088,7 +1089,7 @@ def _add_identifier_args(parser, snapset=False, snapshot=False):
             "-u",
             "--uuid",
             metavar="UUID",
-            type=str,
+            type=UUID,
             help="A snapset UUID",
         )
     if snapshot:
@@ -1103,7 +1104,7 @@ def _add_identifier_args(parser, snapset=False, snapshot=False):
             "-U",
             "--snapshot-uuid",
             metavar="SNAPSHOT_UUID",
-            type=str,
+            type=UUID,
             help="A snapshot UUID",
         )
     parser.add_argument(

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -15,7 +15,6 @@
 Manager interface and plugin infrastructure.
 """
 from subprocess import run, CalledProcessError
-from uuid import UUID
 import logging
 from time import time
 from math import floor
@@ -432,7 +431,7 @@ def select_snapshot_set(select, snapshot_set):
     """
     if select.name and select.name != snapshot_set.name:
         return False
-    if select.uuid and UUID(select.uuid) != snapshot_set.uuid:
+    if select.uuid and select.uuid != snapshot_set.uuid:
         return False
     if select.timestamp and select.timestamp != snapshot_set.timestamp:
         return False
@@ -463,7 +462,7 @@ def select_snapshot(select, snapshot):
     """
     if not select_snapshot_set(select, snapshot.snapshot_set):
         return False
-    if select.snapshot_uuid and UUID(select.snapshot_uuid) != snapshot.uuid:
+    if select.snapshot_uuid and select.snapshot_uuid != snapshot.uuid:
         return False
     if select.snapshot_name and select.snapshot_name != snapshot.name:
         return False

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -680,7 +680,7 @@ class Manager:
 
             self.snapshot_sets.append(snapset)
             self.by_name[snapset.name] = snapset
-            self.by_uuid[str(snapset.uuid)] = snapset
+            self.by_uuid[snapset.uuid] = snapset
             for snapshot in snapset.snapshots:
                 snapshot.snapshot_set = snapset
 
@@ -825,7 +825,7 @@ class Manager:
         for snapshot in snapset.snapshots:
             snapshot.snapshot_set = snapset
         self.by_name[snapset.name] = snapset
-        self.by_uuid[str(snapset.uuid)] = snapset
+        self.by_uuid[snapset.uuid] = snapset
         self.snapshot_sets.append(snapset)
         return snapset
 
@@ -851,7 +851,7 @@ class Manager:
         # Remove references to old set
         self.snapshot_sets.remove(snapset)
         self.by_name.pop(snapset.name)
-        self.by_uuid.pop(str(snapset.uuid))
+        self.by_uuid.pop(snapset.uuid)
 
         for snapshot in snapshots.copy():
             snapshots.remove(snapshot)
@@ -875,7 +875,7 @@ class Manager:
                     old_name, timestamp, snapshots + rollback_snapshots
                 )
                 self.by_name[old_snapset.name] = old_snapset
-                self.by_uuid[str(old_snapset.uuid)] = old_snapset
+                self.by_uuid[old_snapset.uuid] = old_snapset
                 self.snapshot_sets.append(old_snapset)
                 raise SnapmPluginError(
                     f"Could not rename all snapshots for set {old_name}"
@@ -885,7 +885,7 @@ class Manager:
         for snapshot in new_snapset.snapshots:
             snapshot.snapshot_set = new_snapset
         self.by_name[new_snapset.name] = new_snapset
-        self.by_uuid[str(new_snapset.uuid)] = new_snapset
+        self.by_uuid[new_snapset.uuid] = new_snapset
         self.snapshot_sets.append(new_snapset)
         return new_snapset
 
@@ -923,7 +923,7 @@ class Manager:
 
             self.snapshot_sets.remove(snapset)
             self.by_name.pop(snapset.name)
-            self.by_uuid.pop(str(snapset.uuid))
+            self.by_uuid.pop(snapset.uuid)
             deleted += 1
         self._boot_cache.refresh_cache()
         return deleted

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -17,6 +17,7 @@ import logging
 import os
 from subprocess import run
 from shutil import rmtree
+from uuid import UUID
 
 log = logging.getLogger()
 log.level = logging.DEBUG
@@ -182,25 +183,25 @@ class BootTests(unittest.TestCase):
     def test_create_snapshot_boot_entry_bad_uuid(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.create_snapshot_set_boot_entry(
-                uuid="00000000-0000-0000-0000-000000000000"
+                uuid=UUID("00000000-0000-0000-0000-000000000000")
             )
 
     def test_create_snapshot_revert_entry_bad_uuid(self):
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.create_snapshot_set_revert_entry(
-                uuid="00000000-0000-0000-0000-000000000000"
+                uuid=UUID("00000000-0000-0000-0000-000000000000")
             )
 
     def test_create_snapshot_boot_entry_uuid(self):
         sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
-        self.manager.create_snapshot_set_boot_entry(uuid=str(sset.uuid))
+        self.manager.create_snapshot_set_boot_entry(uuid=sset.uuid)
 
         # Clean up boot entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
 
     def test_create_snapshot_revert_entry_uuid(self):
         sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
-        self.manager.create_snapshot_set_revert_entry(uuid=str(sset.uuid))
+        self.manager.create_snapshot_set_revert_entry(uuid=sset.uuid)
 
         # Clean up revert entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
@@ -235,7 +236,7 @@ class BootTests(unittest.TestCase):
         boom.bootloader.load_entries()
         self.addCleanup(self._cleanup_boom_root_path, boot_dir)
         sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
-        self.manager.create_snapshot_set_boot_entry(uuid=str(sset.uuid))
+        self.manager.create_snapshot_set_boot_entry(uuid=sset.uuid)
 
         # Clean up boot entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -234,7 +234,7 @@ class ManagerTests(unittest.TestCase):
     def test_find_snapshot_sets_with_selection_uuid(self):
         set1 = self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
         self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
-        s = snapm.Selection(uuid=str(set1.uuid))
+        s = snapm.Selection(uuid=set1.uuid)
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
 

--- a/tests/test_snapm.py
+++ b/tests/test_snapm.py
@@ -13,6 +13,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 import unittest
 import logging
+from uuid import UUID
 
 import snapm
 
@@ -75,7 +76,7 @@ class SnapmTests(unittest.TestCase):
         self.assertTrue(s.is_single())
 
     def test_Selection_is_single_uuid(self):
-        s = snapm.Selection(uuid="2a6fd226-b400-577f-afe7-0c1a39c78488")
+        s = snapm.Selection(uuid=UUID("2a6fd226-b400-577f-afe7-0c1a39c78488"))
         self.assertTrue(s.is_single())
 
     def test_Selection_is_not_single(self):
@@ -96,7 +97,7 @@ class SnapmTests(unittest.TestCase):
         cmd_args = MockArgs()
         cmd_args.identifier = "2a6fd226-b400-577f-afe7-0c1a39c78488"
         s = snapm.Selection.from_cmd_args(cmd_args)
-        self.assertEqual(cmd_args.identifier, s.uuid)
+        self.assertEqual(UUID(cmd_args.identifier), s.uuid)
 
     def test_Selection_from_cmd_args_name(self):
         cmd_args = MockArgs()
@@ -106,15 +107,9 @@ class SnapmTests(unittest.TestCase):
 
     def test_Selection_from_cmd_args_uuid(self):
         cmd_args = MockArgs()
-        cmd_args.uuid = "2a6fd226-b400-577f-afe7-0c1a39c78488"
+        cmd_args.uuid = UUID("2a6fd226-b400-577f-afe7-0c1a39c78488")
         s = snapm.Selection.from_cmd_args(cmd_args)
         self.assertEqual(cmd_args.uuid, s.uuid)
-
-    def test_Selection_from_cmd_args_bad_uuid(self):
-        cmd_args = MockArgs()
-        cmd_args.uuid = "not-a-uuid"
-        with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            s = snapm.Selection.from_cmd_args(cmd_args)
 
     def test_valid_selection_snapset(self):
         s = snapm.Selection(name="testset0", timestamp=1693921253)


### PR DESCRIPTION
Move the validation of --uuid and --snapshot-uuid argument values from Selection.from_cmd_args() to the ArgumentParser by setting type=UUID for these arguments:

usage: snapm snapset show [-h] [-n NAME] [-u UUID] [-m] [-j] [ID]
snapm snapset show: error: argument -u/--uuid: invalid UUID value: 'bad-uuid'