### PR TITLE
lvm2: check for INVALID status before REVERTING

### DIFF
--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -436,12 +436,12 @@ class Lvm2Snapshot(Snapshot):
     def status(self):
         lv_dict = self._get_lv_dict_cache()
         lv_attr = lv_dict[LVS_LV_ATTR]
+        if lv_attr[LVM_LV_STATE_ATTR_IDX] == LVM_INVALID_ATTR:
+            return SnapStatus.INVALID
         if lv_attr.startswith(LVM_MERGE_SNAP_ATTR):
             return SnapStatus.REVERTING
         if lv_attr[LVM_LV_STATE_ATTR_IDX] == LVM_ACTIVE_ATTR:
             return SnapStatus.ACTIVE
-        if lv_attr[LVM_LV_STATE_ATTR_IDX] == LVM_INVALID_ATTR:
-            return SnapStatus.INVALID
         return SnapStatus.INACTIVE
 
     @property


### PR DESCRIPTION
An lvm2cow snapshot can be both INVALID and REVERTING: in this case the invalid status should take precedence when determining the status of the corresponding Lvm2CowSnapshot object.