### PR TITLE
draft pull request to get feedback for adding blockdev support

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run apt-get update
         run: sudo apt-get -q update
-      - name: Install Ubuntu deps
+      - name: Install Ubuntu snapm deps
         run: >
           DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y
@@ -17,11 +17,17 @@ jobs:
           python3-pycodestyle
           python3-coverage
           python3-flake8
+          python3-dateutil
+          python3-packaging
+          python3-wcwidth
           pycodestyle
           flake8
           pylint
           bandit
           lvm2
+      - name: Install pip dependencies
+        run: >
+          sudo pip install dbus-client-gen dbus-python-client-gen justbytes
       - name: Install Snapshot Manager
         run: >
           sudo pip install -v .
@@ -42,6 +48,38 @@ jobs:
           # Create profiles for kernel variants seen in CI
           sudo boom profile create --from-host --uname-pattern generic --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
           sudo boom profile create --from-host --uname-pattern azure --initramfs-pattern "/initrd.img-%{version}" --kernel-pattern "/vmlinuz-%{version}"
+      - name: Install Ubuntu stratisd deps
+        run: >
+          DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y
+          asciidoc-base
+          clang
+          curl
+          libblkid-dev
+          libcryptsetup-dev
+          libdbus-1-dev
+          libdevmapper-dev
+          libsystemd-dev
+          libudev-dev
+          make
+          sudo
+          thin-provisioning-tools
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Check out stratisd
+        run: git clone https://github.com/stratis-storage/stratisd
+        working-directory: /var/tmp
+      - name: Build stratisd
+        run: make build-all
+        working-directory: /var/tmp/stratisd
+      - name: Install and enable stratisd
+        run: |
+          sudo make install
+          sudo systemctl enable --now stratisd
+        working-directory: /var/tmp/stratisd
+      - name: Install stratis-cli
+        run: sudo pip install stratis-cli
       - name: Check PyCodestyle
         run: >
           pycodestyle snapm --ignore E501,E203,W503

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           toolchain: stable
       - name: Check out stratisd
-        run: git clone https://github.com/stratis-storage/stratisd
+        run: git clone https://github.com/mulkieran/stratisd -b issue_stratisd_3621
         working-directory: /var/tmp
       - name: Build stratisd
         run: make build-all

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _build/
 __pycache__
 doc/html
 doc/doctrees
+.vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ classifiers = [
 ]
 dependencies = [
     "boom-boot >= 1.6.4",
+    "dbus-client-gen >= 0.4",
+    "dbus-python-client-gen >= 0.7",
+    "justbytes >=0.14",
+    "packaging",
+    "python-dateutil",
+    "wcwidth",
 ]
 
 [project.urls]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,12 @@ packages = find:
 scripts = bin/snapm
 install_requires =
     boom-boot >= 1.6.4
+    dbus-client-gen >= 0.4
+    dbus-python-client-gen >= 0.7
+    justbytes >=0.14
+    packaging
+    python-dateutil
+    wcwidth
 
 [options.packages.find]
 exclude =

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -22,6 +22,7 @@ from os.path import ismount, normpath
 import fnmatch
 import inspect
 import os
+import stat
 
 import snapm.manager.plugins
 from snapm.manager.boot import (
@@ -596,7 +597,7 @@ class Manager:
                 _log_error("Disabling plugin %s: %s", plugin_class.__name__, err)
         self.discover_snapshot_sets()
 
-    def _find_and_verify_plugins(self, mount_points, size_policies):
+    def _find_and_verify_plugins(self, mount_points, size_policies, requested_provider=None):
         """
         Find snapshot provider plugins for each mount point in ``mount_points``
         and verify that a provider exists for each mount present.
@@ -616,8 +617,9 @@ class Manager:
                 size_policies[mount],
             )
 
-            if not ismount(mount):
-                raise SnapmPathError(f"Path '{mount}' is not a mount point")
+            if not os.path.exists(mount):
+                raise SnapmPathError(
+                    f"Path '{mount}' does not exist")
 
             for plugin in self.plugins:
                 if plugin.can_snapshot(mount):
@@ -754,7 +756,7 @@ class Manager:
                     f"Snapshot set name cannot include '{char}'"
                 )
 
-    def create_snapshot_set(self, name, mount_point_specs, default_size_policy=None):
+    def create_snapshot_set(self, name, source_point_specs, default_size_policy=None, requested_provider=None):
         """
         Create a snapshot set of the supplied mount points with the name
         ``name``.
@@ -768,11 +770,12 @@ class Manager:
 
         # Parse size policies and normalise mount paths
         (mount_points, size_policies) = _parse_mount_point_specs(
-            mount_point_specs, default_size_policy
+            source_point_specs, default_size_policy
         )
 
         # Initialise provider mapping.
-        provider_map = self._find_and_verify_plugins(mount_points, size_policies)
+        provider_map = self._find_and_verify_plugins(
+            mount_points, size_policies, requested_provider)
 
         for provider in set(provider_map.values()):
             provider.start_transaction()

--- a/snapm/manager/plugins/stratis.py
+++ b/snapm/manager/plugins/stratis.py
@@ -1,0 +1,788 @@
+# Copyright (C) 2024 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# snapm/manager/plugins/stratis.py - Snapshot Manager Stratis plugin
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""
+Stratis snapshot manager plugin
+"""
+from os.path import join as path_join
+from subprocess import run, CalledProcessError
+from time import time
+from uuid import UUID
+
+from dbus.exceptions import DBusException
+
+from snapm import (
+    SnapmCalloutError,
+    SnapmNoSpaceError,
+    SnapmNotFoundError,
+    SnapmPluginError,
+    SizePolicy,
+    SnapStatus,
+    Snapshot,
+)
+from snapm.manager import Plugin
+from snapm.manager.plugins import (
+    DEV_PREFIX,
+    DEV_MAPPER_PREFIX,
+    DMSETUP_CMD,
+    DMSETUP_INFO,
+    DMSETUP_NO_HEADINGS,
+    DMSETUP_COLUMNS,
+    DMSETUP_FIELDS_UUID,
+    parse_snapshot_name,
+    device_from_mount_point,
+    mount_point_space_used,
+    format_snapshot_name,
+    encode_mount_point,
+)
+
+from .stratislib import (
+    StratisdErrors,
+    StratisCliStratisdVersionError,
+    check_stratisd_version,
+    get_object,
+    TOP_OBJECT,
+    Id,
+    IdType,
+    MOFilesystem,
+    MOPool,
+    ObjectManager,
+    Pool,
+    Filesystem,
+    filesystems,
+    pools,
+)
+
+STRATIS_UUID_PREFIX = "stratis-1-"
+
+STRATIS_DECODE_DM_CMD = "stratis-decode-dm"
+STRATIS_DECODE_DM_OUTPUT = "--output"
+STRATIS_DECODE_DM_SYMLINK = "symlink"
+
+DBUS_CACHE_VALID = 5
+
+DEV_STRATIS_PREFIX = "/dev/stratis/"
+
+# Minimum allowed Stratis snapshot size (512MiB)
+MIN_STRATIS_SNAPSHOT_SIZE = 512 * 1024**2
+
+
+def is_stratis_device(devpath):
+    """
+    Test whether ``devpath`` is a Stratis device.
+
+    Return ``True`` if the device at ``devpath`` is a Stratis device or
+    ``False`` otherwise.
+    """
+    if not devpath.startswith(DEV_MAPPER_PREFIX):
+        return False
+    dm_name = devpath.removeprefix(DEV_MAPPER_PREFIX)
+    dmsetup_cmd_args = [
+        DMSETUP_CMD,
+        DMSETUP_INFO,
+        DMSETUP_COLUMNS,
+        DMSETUP_NO_HEADINGS,
+        DMSETUP_FIELDS_UUID,
+        dm_name,
+    ]
+    try:
+        dmsetup_cmd = run(dmsetup_cmd_args, capture_output=True, check=True)
+    except CalledProcessError as err:  # pragma: no cover
+        raise SnapmCalloutError(f"Error calling {DMSETUP_CMD}") from err
+    uuid = dmsetup_cmd.stdout.decode("utf8").strip()
+    return uuid.startswith(STRATIS_UUID_PREFIX)
+
+
+def is_stratisd_running():
+    """
+    Test whether stratisd is running by attempting to get TOP_OBJECT.
+
+    :returns: ``True`` if the stratisd DBus interface is available or
+              ``False`` otherwise.
+    """
+    try:
+        get_object(TOP_OBJECT)
+    except DBusException:
+        return False
+    return True
+
+
+def stratis_devices_present():
+    """
+    Test whether any stratis managed devices are present on the system.
+
+    :returns: ``True`` if stratis devices exist or ``False`` otherwise.
+    """
+    dmsetup_cmd_args = [
+        DMSETUP_CMD,
+        DMSETUP_INFO,
+        DMSETUP_COLUMNS,
+        DMSETUP_NO_HEADINGS,
+        DMSETUP_FIELDS_UUID,
+    ]
+    try:
+        dmsetup_cmd = run(dmsetup_cmd_args, capture_output=True, check=True)
+    except CalledProcessError as err:  # pragma: no cover
+        raise SnapmCalloutError(f"Error calling {DMSETUP_CMD}") from err
+    for uuid in dmsetup_cmd.stdout.decode("utf8").strip().splitlines():
+        if uuid.startswith(STRATIS_UUID_PREFIX):
+            return True
+    return False
+
+
+def pool_fs_from_device_path(devpath):
+    """
+    Return a ``(pool_name, fs_name)`` tuple for the Stratis device at
+    ``devpath``.
+    """
+    stratis_decode_dm_cmd_args = [
+        STRATIS_DECODE_DM_CMD,
+        STRATIS_DECODE_DM_OUTPUT,
+        STRATIS_DECODE_DM_SYMLINK,
+        devpath,
+    ]
+    try:
+        stratis_decode_dm_cmd = run(
+            stratis_decode_dm_cmd_args, capture_output=True, check=True
+        )
+    except CalledProcessError as err:  # pragma: no cover
+        raise SnapmCalloutError(f"Error calling {STRATIS_DECODE_DM_CMD}") from err
+    symlink = stratis_decode_dm_cmd.stdout.decode("utf8").strip()
+    return symlink.removeprefix(DEV_STRATIS_PREFIX).split("/")
+
+
+class StratisSnapshot(Snapshot):
+    """
+    Class for Stratis snapshot objects.
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        name,
+        snapset_name,
+        origin,
+        timestamp,
+        mount_point,
+        provider,
+        pool_name,
+        fs_name,
+    ):
+        super().__init__(name, snapset_name, origin, timestamp, mount_point, provider)
+        self.pool_name = pool_name
+        self.fs_name = fs_name
+        self._pool = None
+        self._filesystem = None
+        self._cache_ts = 0
+        self._get_dbus_cache()
+
+    def __str__(self):
+        return "".join(
+            [
+                super().__str__(),
+                f"\nPool:           {self.pool_name}",
+                f"\nFilesystem:     {self.fs_name}",
+            ]
+        )
+
+    @property
+    def origin(self):
+        return path_join(DEV_PREFIX, "stratis", self.pool_name, self._origin)
+
+    @property
+    def origin_options(self):
+        """
+        File system options needed to specify the origin of this snapshot.
+
+        No file system options are requires for Stratis block snapshots: always
+        return the empty string.
+        """
+        return ""
+
+    @property
+    def devpath(self):
+        return path_join(DEV_PREFIX, "stratis", self.pool_name, self.fs_name)
+
+    @property
+    def status(self):
+        return SnapStatus.ACTIVE
+
+    @property
+    def size(self):
+        (_, filesystem) = self._get_dbus_cache()
+        return int(filesystem.Size())
+
+    @property
+    def free(self):
+        (pool, _) = self._get_dbus_cache()
+        size = int(pool.TotalPhysicalSize())
+        used = int(pool.TotalPhysicalUsed()[1]) if pool.TotalPhysicalUsed()[0] else 0
+        return size - used
+
+    @property
+    def autoactivate(self):
+        # Stratis filesystems always autoactivate with the pool
+        return True
+
+    def invalidate_cache(self):
+        self._pool = None
+        self._filesystem = None
+        self._cache_ts = 0
+
+    def _get_dbus_cache(self):
+        now = time()
+        if (
+            not (self._pool and self._filesystem)
+            or (self._cache_ts + DBUS_CACHE_VALID) < now
+        ):
+            try:
+                proxy = get_object(TOP_OBJECT)
+                managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+            except DBusException as err:
+                raise SnapmPluginError(
+                    f"Failed to communicate with stratisd: {err}"
+                ) from err
+
+            (pool, filesystem) = _get_pool_filesystem(
+                managed_objects, self.pool_name, self.fs_name
+            )
+            self._pool = pool
+            self._filesystem = filesystem
+            self._cache_ts = time()
+        return (self._pool, self._filesystem)
+
+
+def filter_stratis_snapshot(filesystem):
+    """
+    Filter Stratis snapshots.
+
+    Return ``True`` if the filesystem epresented by ``filesystem`` is a stratis
+    snapshot or ``False`` otherwise. The ``filesystem`` argument must be a
+    DBus managed object corresponding to a Stratis filesystem.
+    """
+    return filesystem.Origin()[0]
+
+
+def _snapshot_min_size(policy_size):
+    """
+    Return the minimum snapshot size given the space used by the snapshot
+    mount point.
+
+    :param policy_size: The size suggested by the in-use size policy.
+    :returns: The greater of ``policy_size`` and ``MIN_STRATIS_SNAPSHOT_SIZE``.
+    """
+    return max(MIN_STRATIS_SNAPSHOT_SIZE, policy_size)
+
+
+def _get_pool_filesystem(managed_objects, pool_name, fs_name):
+    """
+    Return pool and filesystem managed objects.
+
+    :param managed_objects: The managed objects to search.
+    :param pool_name: The name of the pool to return.
+    :param fs_name: The name of the filesystem to return, or ``None``
+                    to query only the pool.
+    """
+    props = {"Name": pool_name}
+    pool_object_path = next(
+        pools(props=props).require_unique_match(True).search(managed_objects)
+    )[0]
+
+    if fs_name is not None:
+        fs_id = Id(IdType.NAME, fs_name)
+        fs_props = {"Pool": pool_object_path} | fs_id.managed_objects_key()
+
+        filesystem = [
+            MOFilesystem(info)
+            for objpath, info in filesystems(props=fs_props)
+            .require_unique_match(True)
+            .search(managed_objects)
+        ][0]
+    else:
+        filesystem = None
+
+    pool = [
+        MOPool(info)
+        for objpath, info in pools(props=props)
+        .require_unique_match(True)
+        .search(managed_objects)
+    ][0]
+    return (pool, filesystem)
+
+
+def _origin_uuid_to_fs_name(managed_objects, pool_object_path, origin_uuid):
+    """
+    Return the filesystem corresponding to `origin_uuid`.
+    :param managed_objects: DBus managed objects for the service
+    :param pool_object_path: The pool DBus object path
+    :param origin_uuid: The origin UUID to find.
+    """
+    fs_id = Id(IdType.UUID, UUID(origin_uuid))
+    fs_props = {"Pool": pool_object_path} | fs_id.managed_objects_key()
+
+    filesystem = [
+        MOFilesystem(info)
+        for objpath, info in filesystems(props=fs_props)
+        .require_unique_match(True)
+        .search(managed_objects)
+    ][0]
+
+    return str(filesystem.Name())
+
+
+def _pool_free_space_bytes(managed_objects, pool_name):
+    """
+    Return the free space available as bytes for the Stratis pool named
+    ``pool_name``.
+    """
+    (pool, _) = _get_pool_filesystem(managed_objects, pool_name, None)
+    size = int(pool.TotalPhysicalSize())
+    used = int(pool.TotalPhysicalUsed()[1]) if pool.TotalPhysicalUsed()[0] else 0
+    return size - used
+
+
+def _fs_size_bytes(managed_objects, pool_name, fs_name):
+    """
+    Return the size of the specified filesystem in bytes.
+    """
+    (_, filesystem) = _get_pool_filesystem(managed_objects, pool_name, fs_name)
+    return int(filesystem.Size())
+
+
+class Stratis(Plugin):
+    """
+    Class for Stratis snapshot plugin.
+    """
+
+    name = "stratis"
+    version = "0.1.0"
+    snapshot_class = StratisSnapshot
+
+    def __init__(self, logger):
+        """
+        Initialise the Stratis plugin.
+
+        :param logger: The logger to pass to the Plugin class.
+        """
+        super().__init__(logger)
+        try:
+            check_stratisd_version()
+        except DBusException as err:
+            if stratis_devices_present():
+                self._log_warn(
+                    "Stratis devices present but stratisd is not running: %s", err
+                )
+                self._log_warn(
+                    "Run 'systemctl enable --now stratisd' to manage snapshots for Stratis volumes"
+                )
+            raise SnapmNotFoundError(
+                "Stratisd DBus service not available: {err}"
+            ) from err
+        except StratisCliStratisdVersionError as err:
+            raise SnapmPluginError(f"Stratisd version check failed: {err}") from err
+
+    # pylint: disable=too-many-locals
+    def discover_snapshots(self):
+        """
+        Discover snapshots managed by this plugin class.
+
+        Returns a list of objects that are a subclass of ``Snapshot``.
+        """
+        snapshots = []
+
+        try:
+            proxy = get_object(TOP_OBJECT)
+            managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        except DBusException as err:
+            raise SnapmPluginError(
+                f"Failed to communicate with stratisd: {err}"
+            ) from err
+
+        path_to_name = dict(
+            (path, MOPool(info).Name())
+            for path, info in pools().search(managed_objects)
+        )
+
+        filesystems_with_props = [
+            MOFilesystem(info)
+            for objpath, info in filesystems(props=None)
+            .require_unique_match(False)
+            .search(managed_objects)
+        ]
+
+        for filesystem in filesystems_with_props:
+            if not filter_stratis_snapshot(filesystem):
+                continue
+
+            pool_name = path_to_name[filesystem.Pool()]
+            filesystem_name = str(filesystem.Name())
+
+            origin = _origin_uuid_to_fs_name(
+                managed_objects, filesystem.Pool(), str(filesystem.Origin()[1])
+            )
+
+            try:
+                fields = parse_snapshot_name(filesystem_name, origin)
+            except ValueError:
+                continue
+            if fields is not None:
+                (snapset, timestamp, mount_point) = fields
+                full_name = f"{pool_name}/{filesystem_name}"
+                self._log_debug("Found %s snapshot: %s", self.name, full_name)
+                snapshots.append(
+                    StratisSnapshot(
+                        full_name,
+                        snapset,
+                        origin,
+                        timestamp,
+                        mount_point,
+                        self,
+                        pool_name,
+                        filesystem_name,
+                    )
+                )
+
+        return snapshots
+
+    def can_snapshot(self, mount_point):
+        """
+        Test whether this plugin can snapshot the specified mount point.
+
+        :param mount_point: The mount point path to test.
+        :returns: ``True`` if this plugin can snapshot the file system mounted
+                  at ``mount_point``, or ``False`` otherwise.
+        """
+        device = device_from_mount_point(mount_point)
+        if not is_stratis_device(device):
+            return False
+        if not is_stratisd_running():
+            self._log_error("Stratis mount point specified but stratisd is not running")
+            return False
+        return True
+
+    # pylint: disable=too-many-arguments
+    def _check_free_space(
+        self, managed_objects, pool_name, fs_name, mount_point, size_policy
+    ):
+        """
+        Check for available space in volume group ``vg_name`` for the specified
+        mount point.
+
+        :param vg_name: The name of the volume group to check.
+        :param mount_point: The mount point path to check.
+        :returns: The space used on the mount point.
+        :raises: ``SnapmNoSpaceError`` if the minimum snapshot size exceeds the
+                 available space.
+        """
+        fs_used = mount_point_space_used(mount_point)
+        pool_free = _pool_free_space_bytes(managed_objects, pool_name)
+        fs_size = _fs_size_bytes(managed_objects, pool_name, fs_name)
+        policy = SizePolicy(mount_point, pool_free, fs_used, fs_size, size_policy)
+        snapshot_min_size = _snapshot_min_size(policy.size)
+        if pool_free < (sum(self.size_map[pool_name].values()) + snapshot_min_size):
+            raise SnapmNoSpaceError(
+                f"Stratis pool {pool_name} has insufficient free space to snapshot {mount_point}"
+            )
+        return snapshot_min_size
+
+    # pylint: disable=too-many-arguments
+    def check_create_snapshot(
+        self, origin, snapset_name, timestamp, mount_point, size_policy
+    ):
+        """
+        Perform pre-creation checks before creating a snapshot.
+
+        :param origin: The origin volume for the snapshot.
+        :param snapset_name: The name of the snapshot set to be created.
+        :param timestamp: The snapshot set timestamp.
+        :param mount_point: The mount point path for this snapshot.
+        :raises: ``SnapmNoSpaceError`` if there is insufficient free space to
+                 create the snapshot.
+        """
+        try:
+            proxy = get_object(TOP_OBJECT)
+            managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        except DBusException as err:
+            raise SnapmPluginError(
+                f"Failed to communicate with stratisd: {err}"
+            ) from err
+
+        (pool_name, fs_name) = origin.split("/")
+        if pool_name not in self.size_map:
+            self.size_map[pool_name] = {}
+            self.size_map[pool_name][fs_name] = self._check_free_space(
+                managed_objects, pool_name, fs_name, mount_point, size_policy
+            )
+
+    # pylint: disable=too-many-arguments
+    def create_snapshot(
+        self, origin, snapset_name, timestamp, mount_point, size_policy
+    ):
+        """
+        Create a snapshot of ``origin`` in the snapset named ``snapset_name``.
+
+        :param origin: The origin volume for the snapshot.
+        :param snapset_name: The name of the snapshot set to be created.
+        :param timestamp: The snapshot set timestamp.
+        :param mount_point: The mount point path for this snapshot.
+        :raises: ``SnapmNoSpaceError`` if there is insufficient free space to
+                 create the snapshot.
+        """
+        (pool_name, fs_name) = origin.split("/")
+
+        snapshot_name = format_snapshot_name(
+            fs_name, snapset_name, timestamp, encode_mount_point(mount_point)
+        )
+
+        try:
+            proxy = get_object(TOP_OBJECT)
+            managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        except DBusException as err:
+            raise SnapmPluginError(
+                f"Failed to communicate with stratisd: {err}"
+            ) from err
+
+        self._check_free_space(
+            managed_objects, pool_name, fs_name, mount_point, size_policy
+        )
+
+        self._log_debug(
+            "Creating Stratis snapshot for %s/%s mounted at %s",
+            pool_name,
+            fs_name,
+            mount_point,
+        )
+        (pool_object_path, _) = next(
+            pools(props={"Name": pool_name})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+        (origin_fs_object_path, _) = next(
+            filesystems(props={"Name": fs_name, "Pool": pool_object_path})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+
+        ((changed, _), return_code, message) = Pool.Methods.SnapshotFilesystem(
+            get_object(pool_object_path),
+            {"origin": origin_fs_object_path, "snapshot_name": snapshot_name},
+        )
+
+        if return_code != StratisdErrors.OK:  # pragma: no cover
+            raise SnapmPluginError(message)
+
+        if not changed:  # pragma: no cover
+            raise SnapmPluginError(
+                f"Stratis daemon reported no change creating snapshot {snapshot_name}"
+            )
+
+        return StratisSnapshot(
+            f"{pool_name}/{snapshot_name}",
+            snapset_name,
+            fs_name,
+            timestamp,
+            mount_point,
+            self,
+            pool_name,
+            snapshot_name,
+        )
+
+    def origin_from_mount_point(self, mount_point):
+        """
+        Return a string representing the origin from a given mount point path.
+        """
+        device = device_from_mount_point(mount_point)
+        if not is_stratis_device(device):
+            return None
+        (pool_name, fs_name) = pool_fs_from_device_path(device)
+        return f"{pool_name}/{fs_name}"
+
+    def delete_snapshot(self, name):
+        """
+        Delete the snapshot named ``name``
+
+        :param name: The name of the snapshot to be removed.
+        """
+        (pool_name, fs_name) = name.split("/")
+        fs_name = [fs_name]
+
+        try:
+            proxy = get_object(TOP_OBJECT)
+            managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        except DBusException as err:
+            raise SnapmPluginError(
+                f"Failed to communicate with stratisd: {err}"
+            ) from err
+
+        (pool_object_path, _) = next(
+            pools(props={"Name": pool_name})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+
+        requested_names = frozenset(fs_name)
+
+        pool_filesystems = {
+            MOFilesystem(info).Name(): op
+            for (op, info) in filesystems(props={"Pool": pool_object_path}).search(
+                managed_objects
+            )
+        }
+        already_removed = requested_names.difference(frozenset(pool_filesystems.keys()))
+
+        if already_removed != frozenset():  # pragma: no cover
+            raise SnapmPluginError(
+                f"Stratisd destroy reported snapshot already removed: {already_removed}"
+            )
+
+        fs_object_paths = [
+            op for (name, op) in pool_filesystems.items() if name in requested_names
+        ]
+
+        (
+            (destroyed, list_destroyed),
+            return_code,
+            message,
+        ) = Pool.Methods.DestroyFilesystems(
+            get_object(pool_object_path), {"filesystems": fs_object_paths}
+        )
+
+        if return_code != StratisdErrors.OK:  # pragma: no cover
+            raise SnapmPluginError(message)
+
+        if not destroyed or len(list_destroyed) < len(
+            fs_object_paths
+        ):  # pragma: no cover
+            raise SnapmPluginError(
+                (
+                    f"Expected to destroy the specified filesystems in pool "
+                    f"{pool_name} but stratisd reports that it did not"
+                    f"actually destroy some or all of the filesystems "
+                    f"requested"
+                )
+            )
+
+    # pylint: disable=too-many-arguments
+    def rename_snapshot(self, old_name, origin, snapset_name, timestamp, mount_point):
+        """
+        Rename the snapshot named ``old_name`` according to the provided
+        snapshot field values.
+
+        :param old_name: The original name of the snapshot to be renamed.
+        :param origin: The origin volume for the snapshot.
+        :param snapset_name: The new name of the snapshot set.
+        :param timestamp: The snapshot set timestamp.
+        :param mount_point: The mount point of the snapshot.
+        """
+        (pool_name, fs_name) = old_name.split("/")
+        origin = origin.removeprefix(DEV_STRATIS_PREFIX).split("/")[1]
+        new_name = format_snapshot_name(
+            origin, snapset_name, timestamp, encode_mount_point(mount_point)
+        )
+
+        self._log_debug(
+            "Renaming snapshot from %s to %s",
+            old_name,
+            new_name,
+        )
+
+        try:
+            proxy = get_object(TOP_OBJECT)
+            managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        except DBusException as err:
+            raise SnapmPluginError(
+                f"Failed to communicate with stratisd: {err}"
+            ) from err
+
+        (pool_object_path, _) = next(
+            pools(props={"Name": pool_name})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+        (fs_object_path, _) = next(
+            filesystems(props={"Name": fs_name, "Pool": pool_object_path})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+        ((changed, _), return_code, message) = Filesystem.Methods.SetName(
+            get_object(fs_object_path), {"name": new_name}
+        )
+
+        if return_code != StratisdErrors.OK:  # pragma: no cover
+            raise SnapmPluginError(
+                f"Rename failed: stratisd returned error {return_code}, {message})"
+            )
+
+        if not changed:
+            raise SnapmPluginError(f"Rename reported no change: {new_name}")
+
+        return StratisSnapshot(
+            f"{pool_name}/{new_name}",
+            snapset_name,
+            fs_name,
+            timestamp,
+            mount_point,
+            self,
+            pool_name,
+            new_name,
+        )
+
+    def check_revert_snapshot(self, name, origin):
+        """
+        Check whether this snapshot can be reverted or not. This method returns
+        if the current snapshot can be reverted and raises an exception if not.
+
+        :returns: None
+        :raises: ``NotImplementedError`` if this plugin does not support the
+        revert operation, ``SnapmBusyError`` if the snapshot is already in the
+        process of being reverted to another snapshot state or
+        ``SnapmPluginError`` if another reason prevents the snapshot from being
+        merged.
+        """
+        raise NotImplementedError("Stratis does not currently implement revert")
+
+    def revert_snapshot(self, name):
+        """
+        Revert the state of the content of the origin to the content at the
+        time the snapshot was taken.
+
+        For Stratis snapshots of in-use filesystems this will take place at
+        the next activation (typically a reboot into the revert boot entry
+        for the snapshot set).
+        """
+        raise NotImplementedError
+
+    def activate_snapshot(self, name):
+        """
+        Activate the snapshot named ``name``
+
+        :param name: The name of the snapshot to be activated.
+        """
+        return
+
+    def deactivate_snapshot(self, name):
+        """
+        Deactivate the snapshot named ``name``
+
+        :param name: The name of the snapshot to be deactivated.
+        """
+        return
+
+    def set_autoactivate(self, name, auto=False):
+        """
+        Set the autoactivation state of the snapshot named ``name``.
+
+        :param name: The name of the snapshot to be modified.
+        :param auto: ``True`` to enable autoactivation or ``False`` otherwise.
+        """
+        return

--- a/snapm/manager/plugins/stratis.py
+++ b/snapm/manager/plugins/stratis.py
@@ -14,8 +14,10 @@
 """
 Stratis snapshot manager plugin
 """
+from os import stat
 from os.path import join as path_join
 from subprocess import run, CalledProcessError
+from stat import S_ISBLK
 from time import time
 from uuid import UUID
 
@@ -509,6 +511,9 @@ class Stratis(Plugin):
         :returns: ``True`` if this plugin can snapshot the file system mounted
                   at ``mount_point``, or ``False`` otherwise.
         """
+        if S_ISBLK(stat(mount_point).st_mode):
+            return False
+
         device = device_from_mount_point(mount_point)
         if not is_stratis_device(device):
             return False

--- a/snapm/manager/plugins/stratislib/__init__.py
+++ b/snapm/manager/plugins/stratislib/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Package mediating dbus actions.
+"""
+
+from ._stratisd_version import check_stratisd_version
+from ._stratisd_constants import StratisdErrors
+from ._errors import (
+    StratisCliGenerationError,
+    StratisCliEnvironmentError,
+    StratisCliStratisdVersionError,
+)
+from ._connection import get_object
+from ._constants import TOP_OBJECT, Id, IdType
+from ._data import (
+    MOFilesystem,
+    MOPool,
+    ObjectManager,
+    Pool,
+    Filesystem,
+    filesystems,
+    pools,
+)
+
+__all__ = [
+    "check_stratisd_version",
+    "StratisdErrors",
+    "StratisCliGenerationError",
+    "StratisCliEnvironmentError",
+    "StratisCliStratisdVersionError",
+    "get_object",
+    "TOP_OBJECT",
+    "Id",
+    "IdType",
+    "MOFilesystem",
+    "MOPool",
+    "ObjectManager",
+    "Pool",
+    "Filesystem",
+    "filesystems",
+    "pools",
+]

--- a/snapm/manager/plugins/stratislib/_connection.py
+++ b/snapm/manager/plugins/stratislib/_connection.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Low-level interactions with the D-Bus.
+"""
+
+# isort: THIRDPARTY
+import dbus
+
+from ._constants import SERVICE
+
+
+class Bus:
+    """
+    Our bus.
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    _BUS = None
+
+    @staticmethod
+    def get_bus():
+        """
+        Get our bus.
+        """
+        if Bus._BUS is None:
+            Bus._BUS = dbus.SystemBus()
+
+        return Bus._BUS
+
+
+def get_object(object_path):
+    """
+    Get an object from an object path.
+
+    :param str object_path: an object path with a valid format
+    :returns: the proxy object corresponding to the object path
+    :rtype: ProxyObject
+    """
+    return Bus.get_bus().get_object(SERVICE, object_path, introspect=False)

--- a/snapm/manager/plugins/stratislib/_constants.py
+++ b/snapm/manager/plugins/stratislib/_constants.py
@@ -1,0 +1,83 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+General constants.
+"""
+# isort: STDLIB
+from enum import Enum
+
+# isort: THIRDPARTY
+from packaging.specifiers import Version
+
+SERVICE = "org.storage.stratis3"
+TOP_OBJECT = "/org/storage/stratis3"
+
+MAXIMUM_STRATISD_VERSION = "4.0.0"
+MINIMUM_STRATISD_VERSION = "3.7.0"
+assert Version(MINIMUM_STRATISD_VERSION) < Version(MAXIMUM_STRATISD_VERSION)
+
+REVISION = f"r{MINIMUM_STRATISD_VERSION.split('.')[1]}"
+
+BLOCKDEV_INTERFACE = f"org.storage.stratis3.blockdev.{REVISION}"
+FILESYSTEM_INTERFACE = f"org.storage.stratis3.filesystem.{REVISION}"
+MANAGER_INTERFACE = f"org.storage.stratis3.Manager.{REVISION}"
+POOL_INTERFACE = f"org.storage.stratis3.pool.{REVISION}"
+REPORT_INTERFACE = f"org.storage.stratis3.Report.{REVISION}"
+
+
+class IdType(Enum):
+    """
+    Whether the pool identifier is a UUID or a name.
+    """
+
+    UUID = 0
+    NAME = 1
+
+
+class Id:
+    """
+    Generic management of ids when either a UUID or name can be used.
+    """
+
+    def __init__(self, id_type, id_value):
+        """
+        Initialize the object.
+        """
+        self.id_type = id_type
+        self.id_value = id_value
+
+    def managed_objects_key(self):
+        """
+        Return key for managed objects.
+
+        Precondition: the D-Bus property that identifies the Name or the
+        Uuid will always be the same.
+        """
+        return {"Uuid" if self.id_type is IdType.UUID else "Name": self.dbus_value()}
+
+    def is_uuid(self):
+        """
+        True if the id is a UUID, otherwise false.
+        """
+        return self.id_type == IdType.UUID
+
+    def dbus_value(self):
+        """
+        Returns a string value for matching D-Bus things.
+        """
+        return self.id_value.hex if self.id_type is IdType.UUID else self.id_value
+
+    def __str__(self):
+        pool_id_type_str = "UUID" if self.id_type is IdType.UUID else "name"
+        return f"{pool_id_type_str} {self.id_value}"

--- a/snapm/manager/plugins/stratislib/_data.py
+++ b/snapm/manager/plugins/stratislib/_data.py
@@ -1,0 +1,142 @@
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+XML interface specifications.
+"""
+# isort: STDLIB
+import os
+import xml.etree.ElementTree as ET  # nosec B405
+
+# isort: FIRSTPARTY
+from dbus_client_gen import (
+    DbusClientGenerationError,
+    managed_object_class,
+    mo_query_builder,
+)
+from dbus_python_client_gen import DPClientGenerationError, make_class
+
+from ._errors import StratisCliGenerationError
+from ._constants import (
+    BLOCKDEV_INTERFACE,
+    FILESYSTEM_INTERFACE,
+    MANAGER_INTERFACE,
+    POOL_INTERFACE,
+    REPORT_INTERFACE,
+)
+from ._environment import get_timeout
+from ._introspect import SPECS
+
+DBUS_TIMEOUT_SECONDS = 120
+
+
+try:
+    # pylint: disable=invalid-name
+
+    timeout = get_timeout(
+        os.environ.get("STRATIS_DBUS_TIMEOUT", DBUS_TIMEOUT_SECONDS * 1000)
+    )
+
+    report_spec = ET.fromstring(SPECS[REPORT_INTERFACE])  # nosec B314
+    Report = make_class("Report", report_spec, timeout)
+
+    filesystem_spec = ET.fromstring(SPECS[FILESYSTEM_INTERFACE])  # nosec B314
+    Filesystem = make_class("Filesystem", filesystem_spec, timeout)
+    MOFilesystem = managed_object_class("MOFilesystem", filesystem_spec)
+    filesystems = mo_query_builder(filesystem_spec)
+
+    pool_spec = ET.fromstring(SPECS[POOL_INTERFACE])  # nosec B314
+    Pool = make_class("Pool", pool_spec, timeout)
+    MOPool = managed_object_class("MOPool", pool_spec)
+    pools = mo_query_builder(pool_spec)
+
+    blockdev_spec = ET.fromstring(SPECS[BLOCKDEV_INTERFACE])  # nosec B314
+    MODev = managed_object_class("MODev", blockdev_spec)
+    devs = mo_query_builder(blockdev_spec)
+
+    Manager = make_class(
+        "Manager", ET.fromstring(SPECS[MANAGER_INTERFACE]), timeout  # nosec B314
+    )
+
+    ObjectManager = make_class(
+        "ObjectManager",
+        ET.fromstring(SPECS["org.freedesktop.DBus.ObjectManager"]),  # nosec B314
+        timeout,
+    )
+
+    # Specification for the lowest manager interface supported by the major
+    # version of stratisd on which this version of the CLI depends.
+    # This minimal specification includes only the specification for the
+    # Version property.
+    manager_spec = """
+    <interface name="org.storage.stratis3.Manager.r0">
+        <property access="read" name="Version" type="s">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+        </property>
+    </interface>
+    """
+    Manager0 = make_class(
+        "Manager0", ET.fromstring(manager_spec), timeout  # nosec B314
+    )
+
+# Do not expect to get coverage on Generation errors.
+# These can only occurs if the XML data in _SPECS is ill-formed; we have
+# complete control over that data and can expect it to be valid.
+except DPClientGenerationError as err:  # pragma: no cover
+    raise StratisCliGenerationError(
+        "Failed to generate some class needed for invoking dbus-python methods"
+    ) from err
+except DbusClientGenerationError as err:  # pragma: no cover
+    raise StratisCliGenerationError(
+        "Failed to generate some class needed for examining D-Bus data"
+    ) from err
+
+
+def _add_abs_path_assertion(klass, method_name, key):
+    """
+    Set method_name of method_klass to a new method which checks that the
+    device paths values at key are absolute paths.
+
+    :param klass: the klass to which this metthod belongs
+    :param str method_name: the name of the method
+    :param str key: the key at which the paths can be found in the arguments
+    """
+    method_class = getattr(klass, "Methods")
+    orig_method = getattr(method_class, method_name)
+
+    def new_method(proxy, args):
+        """
+        New CreatePool method
+        """
+        rel_paths = [path for path in args[key] if not os.path.isabs(path)]
+        assert (
+            rel_paths == []
+        ), f"Precondition violated: paths {', '.join(rel_paths)} should be absolute"
+        return orig_method(proxy, args)
+
+    setattr(method_class, method_name, new_method)
+
+
+try:
+    _add_abs_path_assertion(Manager, "CreatePool", "devices")
+    _add_abs_path_assertion(Pool, "InitCache", "devices")
+    _add_abs_path_assertion(Pool, "AddCacheDevs", "devices")
+    _add_abs_path_assertion(Pool, "AddDataDevs", "devices")
+
+except AttributeError as err:  # pragma: no cover
+    # This can only happen if the expected method is missing from the XML spec
+    # or code generation has a bug, we will never test for these conditions.
+    raise StratisCliGenerationError(
+        "Malformed class definition; could not access a class or method in "
+        "the generated class definition"
+    ) from err

--- a/snapm/manager/plugins/stratislib/_environment.py
+++ b/snapm/manager/plugins/stratislib/_environment.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Environment functions.
+"""
+
+from ._errors import StratisCliEnvironmentError
+
+
+def get_timeout(value):
+    """
+    Turn an input str or int into a float timeout value.
+
+    :param value: the input str or int
+    :type value: str or int
+    :raises StratisCliEnvironmentError:
+    :returns: float
+    """
+
+    maximum_dbus_timeout_ms = 1073741823
+
+    # Ensure the input str is not a float
+    if isinstance(value, float):
+        raise StratisCliEnvironmentError(
+            "The timeout value provided is a float; it should be an integer."
+        )
+
+    try:
+        timeout_int = int(value)
+
+    except ValueError as err:
+        raise StratisCliEnvironmentError(
+            "The timeout value provided is not an integer."
+        ) from err
+
+    # Ensure the integer is not too small
+    if timeout_int < -1:
+        raise StratisCliEnvironmentError(
+            "The timeout value provided is smaller than the smallest acceptable value, -1."
+        )
+
+    # Ensure the integer is not too large
+    if timeout_int > maximum_dbus_timeout_ms:
+        raise StratisCliEnvironmentError(
+            f"The timeout value provided exceeds the largest acceptable value, "
+            f"{maximum_dbus_timeout_ms}."
+        )
+
+    # Convert from milliseconds to seconds
+    return timeout_int / 1000

--- a/snapm/manager/plugins/stratislib/_error_codes.py
+++ b/snapm/manager/plugins/stratislib/_error_codes.py
@@ -1,0 +1,239 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Error codes
+"""
+# isort: STDLIB
+from enum import Enum, IntEnum
+
+
+class Level(Enum):
+    """
+    Error levels.
+    """
+
+    ERROR = "E"
+    WARNING = "W"
+    INFO = "I"
+
+    def __str__(self):
+        return self.value
+
+
+class PoolMaintenanceErrorCode(IntEnum):
+    """
+    Maintenance error codes for the pool.
+    """
+
+    NO_IPC_REQUESTS = 1
+    NO_POOL_CHANGES = 2
+
+    def __str__(self):
+        return f"{Level.ERROR}M{str(self.value).zfill(3)}"
+
+    @staticmethod
+    def from_str(code_str):
+        """
+        Discover the code, if any, from the code string.
+
+        :returns: the code if it finds a match, otherwise None
+        :rtype: PoolMaintenanceErrorCode or NoneType
+        """
+        return next(
+            (code for code in PoolMaintenanceErrorCode if code_str == str(code)), None
+        )
+
+    def explain(self):
+        """
+        Return an explanation of the error return code.
+        """
+        if self is PoolMaintenanceErrorCode.NO_IPC_REQUESTS:
+            return (
+                "The pool will return an error on any IPC request that could "
+                "cause a change in the pool state, for example, a request to "
+                "rename a filesystem. It will still be able to respond to "
+                "purely informational requests."
+            )
+
+        if self is PoolMaintenanceErrorCode.NO_POOL_CHANGES:
+            return (
+                "The pool is unable to manage itself by reacting to events, "
+                "such as devicemapper events, that might require it to take "
+                "any maintenance operations."
+            )
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def summarize(self):
+        """
+        Return a short summary of the return code.
+        """
+        if self is PoolMaintenanceErrorCode.NO_IPC_REQUESTS:
+            return "Pool state changes not possible"
+
+        if self is PoolMaintenanceErrorCode.NO_POOL_CHANGES:
+            return "Pool maintenance operations not possible"
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+
+class PoolAllocSpaceErrorCode(IntEnum):
+    """
+    Code if the pool has run out of space to allocate.
+    """
+
+    NO_ALLOC_SPACE = 1
+
+    def __str__(self):
+        return f"{Level.WARNING}S{str(self.value).zfill(3)}"
+
+    def explain(self):
+        """
+        Return an explanation of the return code.
+        """
+        if self is PoolAllocSpaceErrorCode.NO_ALLOC_SPACE:
+            return (
+                "Every device belonging to the pool has been fully allocated. "
+                "To increase the allocable space, add additional data devices "
+                "to the pool."
+            )
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def summarize(self):
+        """
+        Return a short summary of the return code.
+        """
+        if self is PoolAllocSpaceErrorCode.NO_ALLOC_SPACE:
+            return "All devices fully allocated"
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    @staticmethod
+    def from_str(code_str):
+        """
+        Discover the code, if any, from the code string.
+
+        :returns: the code if it finds a match, otherwise None
+        :rtype: PoolAllocSpaceErrorCode or NoneType
+        """
+        return next(
+            (code for code in PoolAllocSpaceErrorCode if code_str == str(code)), None
+        )
+
+
+class PoolDeviceSizeChangeCode(IntEnum):
+    """
+    Codes for identifying for a pool if a device that belongs to the pool has
+    been detected to have increased or reduced in size.
+    """
+
+    DEVICE_SIZE_INCREASED = 1
+    DEVICE_SIZE_DECREASED = 2
+
+    def __str__(self):
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return f"{Level.INFO}DS{str(self.value).zfill(3)}"
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return f"{Level.WARNING}DS{str(self.value).zfill(3)}"
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def explain(self):
+        """
+        Return an explanation of the return code.
+        """
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "increased in size."
+            )
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "decreased in size."
+            )
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def summarize(self):
+        """
+        Return a short summary of the return code.
+        """
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return "A device in this pool has increased in size."
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return "A device in this pool has decreased in size."
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    @staticmethod
+    def from_str(code_str):
+        """
+        Discover the code, if any, from the code string.
+
+        :returns: the code if it finds a match, otherwise None
+        :rtype: PoolAllocSpaceErrorCode or NoneType
+        """
+        return next(
+            (code for code in PoolDeviceSizeChangeCode if code_str == str(code)), None
+        )
+
+
+class PoolErrorCode:
+    """
+    Summary class for all pool error codes.
+    """
+
+    CLASSES = [
+        PoolMaintenanceErrorCode,
+        PoolAllocSpaceErrorCode,
+        PoolDeviceSizeChangeCode,
+    ]
+
+    @staticmethod
+    def codes():
+        """
+        Return all pool error codes.
+        """
+        return [code for c in PoolErrorCode.CLASSES for code in list(c)]
+
+    @staticmethod
+    def error_from_str(error_code):
+        """
+        Obtain an error object from a distinguishing error string.
+
+        :param str error_code:
+        :returns: error object
+        :raises: StopIteration if no match found
+        """
+        return next(
+            (
+                code
+                for code in (c.from_str(error_code) for c in PoolErrorCode.CLASSES)
+                if code is not None
+            )
+        )
+
+    @staticmethod
+    def explain(error_code):
+        """
+        Return explanation for error code, else None.
+
+        :param str error_code:
+        """
+        return PoolErrorCode.error_from_str(error_code).explain()

--- a/snapm/manager/plugins/stratislib/_errors.py
+++ b/snapm/manager/plugins/stratislib/_errors.py
@@ -1,0 +1,71 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Error hierarchy for stratis cli.
+"""
+
+
+class StratisCliError(Exception):
+    """
+    Top-level stratis cli error.
+    """
+
+
+class StratisCliRuntimeError(StratisCliError):
+    """
+    Exception raised while an action is being performed and as a result of
+    the requested action.
+    """
+
+
+class StratisCliGenerationError(StratisCliError):
+    """
+    Exception that occurs during generation of classes.
+    """
+
+
+class StratisCliEnvironmentError(StratisCliError):
+    """
+    Exception that occurs during processing of environment variables.
+    """
+
+
+class StratisCliStratisdVersionError(StratisCliRuntimeError):
+    """
+    Raised if stratisd version does not meet CLI version requirements.
+    """
+
+    def __init__(self, actual_version, minimum_version, maximum_version):
+        """
+        Initializer.
+        :param tuple actual_version: stratisd's actual version
+        :param tuple minimum_version: the minimum version required
+        :param tuple maximum_version: the maximum version allowed
+        """
+        # pylint: disable=super-init-not-called
+        self.actual_version = actual_version
+        self.minimum_version = minimum_version
+        self.maximum_version = maximum_version
+
+    def __str__(self):
+        fmt_str = (
+            "stratisd version %s does not meet stratis version "
+            "requirements; the version must be at least %s and no more "
+            "than %s"
+        )
+        return fmt_str % (
+            self.actual_version,
+            self.minimum_version,
+            self.maximum_version,
+        )

--- a/snapm/manager/plugins/stratislib/_introspect.py
+++ b/snapm/manager/plugins/stratislib/_introspect.py
@@ -127,6 +127,7 @@ SPECS = {
     <property name="Devnode" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates" />
     </property>
+    <property name="MergeScheduled" type="b" access="readwrite" />
     <property name="Name" type="s" access="read" />
     <property name="Origin" type="(bs)" access="read" />
     <property name="Pool" type="o" access="read">
@@ -179,6 +180,13 @@ SPECS = {
       <arg name="return_code" type="q" direction="out" />
       <arg name="return_string" type="s" direction="out" />
     </method>
+    <method name="FilesystemMetadata">
+      <arg name="fs_name" type="(bs)" direction="in" />
+      <arg name="current" type="b" direction="in" />
+      <arg name="results" type="s" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
     <method name="GrowPhysicalDevice">
       <arg name="dev" type="s" direction="in" />
       <arg name="results" type="b" direction="out" />
@@ -188,6 +196,12 @@ SPECS = {
     <method name="InitCache">
       <arg name="devices" type="as" direction="in" />
       <arg name="results" type="(bao)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="Metadata">
+      <arg name="current" type="b" direction="in" />
+      <arg name="results" type="s" direction="out" />
       <arg name="return_code" type="q" direction="out" />
       <arg name="return_string" type="s" direction="out" />
     </method>
@@ -234,6 +248,9 @@ SPECS = {
     <property name="FsLimit" type="t" access="readwrite" />
     <property name="HasCache" type="b" access="read" />
     <property name="KeyDescription" type="(b(bs))" access="read" />
+    <property name="MetadataVersion" type="t" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
     <property name="Name" type="s" access="read" />
     <property name="NoAllocSpace" type="b" access="read" />
     <property name="Overprovisioning" type="b" access="readwrite" />

--- a/snapm/manager/plugins/stratislib/_introspect.py
+++ b/snapm/manager/plugins/stratislib/_introspect.py
@@ -1,0 +1,247 @@
+"""
+XML introspection data for Stratis
+"""
+
+SPECS = {
+    "org.freedesktop.DBus.ObjectManager": """
+<interface name="org.freedesktop.DBus.ObjectManager">
+    <method name="GetManagedObjects">
+      <arg name="objpath_interfaces_and_properties" type="a{oa{sa{sv}}}" direction="out" />
+    </method>
+  </interface>
+""",
+    "org.storage.stratis3.Manager.r7": """
+<interface name="org.storage.stratis3.Manager.r7">
+    <method name="CreatePool">
+      <arg name="name" type="s" direction="in" />
+      <arg name="devices" type="as" direction="in" />
+      <arg name="key_desc" type="(bs)" direction="in" />
+      <arg name="clevis_info" type="(b(ss))" direction="in" />
+      <arg name="result" type="(b(oao))" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="DestroyPool">
+      <arg name="pool" type="o" direction="in" />
+      <arg name="result" type="(bs)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="EngineStateReport">
+      <arg name="result" type="s" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="ListKeys">
+      <arg name="result" type="as" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="RefreshState">
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="SetKey">
+      <arg name="key_desc" type="s" direction="in" />
+      <arg name="key_fd" type="h" direction="in" />
+      <arg name="result" type="(bb)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="StartPool">
+      <arg name="id" type="s" direction="in" />
+      <arg name="id_type" type="s" direction="in" />
+      <arg name="unlock_method" type="(bs)" direction="in" />
+      <arg name="result" type="(b(oaoao))" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="StopPool">
+      <arg name="id" type="s" direction="in" />
+      <arg name="id_type" type="s" direction="in" />
+      <arg name="result" type="(bs)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="UnsetKey">
+      <arg name="key_desc" type="s" direction="in" />
+      <arg name="result" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <property name="StoppedPools" type="a{sa{sv}}" access="read" />
+    <property name="Version" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+  </interface>
+""",
+    "org.storage.stratis3.Report.r7": """
+<interface name="org.storage.stratis3.Report.r7">
+    <method name="GetReport">
+      <arg name="name" type="s" direction="in" />
+      <arg name="result" type="s" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+  </interface>
+""",
+    "org.storage.stratis3.blockdev.r7": """
+<interface name="org.storage.stratis3.blockdev.r7">
+    <property name="Devnode" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="HardwareInfo" type="(bs)" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="InitializationTime" type="t" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="NewPhysicalSize" type="(bs)" access="read" />
+    <property name="PhysicalPath" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="Pool" type="o" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="Tier" type="q" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
+    <property name="TotalPhysicalSize" type="s" access="read" />
+    <property name="UserInfo" type="(bs)" access="readwrite" />
+    <property name="Uuid" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+  </interface>
+""",
+    "org.storage.stratis3.filesystem.r7": """
+<interface name="org.storage.stratis3.filesystem.r7">
+    <method name="SetName">
+      <arg name="name" type="s" direction="in" />
+      <arg name="result" type="(bs)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <property name="Created" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="Devnode" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="invalidates" />
+    </property>
+    <property name="Name" type="s" access="read" />
+    <property name="Origin" type="(bs)" access="read" />
+    <property name="Pool" type="o" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="Size" type="s" access="read" />
+    <property name="SizeLimit" type="(bs)" access="readwrite" />
+    <property name="Used" type="(bs)" access="read" />
+    <property name="Uuid" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+  </interface>
+""",
+    "org.storage.stratis3.pool.r7": """
+<interface name="org.storage.stratis3.pool.r7">
+    <method name="AddCacheDevs">
+      <arg name="devices" type="as" direction="in" />
+      <arg name="results" type="(bao)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="AddDataDevs">
+      <arg name="devices" type="as" direction="in" />
+      <arg name="results" type="(bao)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="BindClevis">
+      <arg name="pin" type="s" direction="in" />
+      <arg name="json" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="BindKeyring">
+      <arg name="key_desc" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="CreateFilesystems">
+      <arg name="specs" type="a(s(bs)(bs))" direction="in" />
+      <arg name="results" type="(ba(os))" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="DestroyFilesystems">
+      <arg name="filesystems" type="ao" direction="in" />
+      <arg name="results" type="(bas)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="GrowPhysicalDevice">
+      <arg name="dev" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="InitCache">
+      <arg name="devices" type="as" direction="in" />
+      <arg name="results" type="(bao)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="RebindClevis">
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="RebindKeyring">
+      <arg name="key_desc" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="SetName">
+      <arg name="name" type="s" direction="in" />
+      <arg name="result" type="(bs)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="SnapshotFilesystem">
+      <arg name="origin" type="o" direction="in" />
+      <arg name="snapshot_name" type="s" direction="in" />
+      <arg name="result" type="(bo)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="UnbindClevis">
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="UnbindKeyring">
+      <arg name="results" type="b" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <property name="AllocatedSize" type="s" access="read" />
+    <property name="AvailableActions" type="s" access="read" />
+    <property name="ClevisInfo" type="(b(b(ss)))" access="read" />
+    <property name="Encrypted" type="b" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+    <property name="FsLimit" type="t" access="readwrite" />
+    <property name="HasCache" type="b" access="read" />
+    <property name="KeyDescription" type="(b(bs))" access="read" />
+    <property name="Name" type="s" access="read" />
+    <property name="NoAllocSpace" type="b" access="read" />
+    <property name="Overprovisioning" type="b" access="readwrite" />
+    <property name="TotalPhysicalSize" type="s" access="read" />
+    <property name="TotalPhysicalUsed" type="(bs)" access="read" />
+    <property name="Uuid" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+  </interface>
+""",
+}

--- a/snapm/manager/plugins/stratislib/_stratisd_constants.py
+++ b/snapm/manager/plugins/stratislib/_stratisd_constants.py
@@ -1,0 +1,31 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Stratisd error classes.
+"""
+
+
+from enum import IntEnum
+
+
+class StratisdErrors(IntEnum):
+    """
+    Stratisd Errors
+    """
+
+    OK = 0
+    ERROR = 1
+
+    def __str__(self):
+        return self.name

--- a/snapm/manager/plugins/stratislib/_stratisd_version.py
+++ b/snapm/manager/plugins/stratislib/_stratisd_version.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Check version of stratisd
+"""
+
+# isort: THIRDPARTY
+from packaging.specifiers import SpecifierSet, Version
+
+from ._errors import StratisCliStratisdVersionError
+from ._connection import get_object
+from ._constants import MAXIMUM_STRATISD_VERSION, MINIMUM_STRATISD_VERSION, TOP_OBJECT
+
+
+def check_stratisd_version():
+    """
+    Checks that the version of stratisd that is running is compatible with
+    this version of the CLI.
+
+    :raises StratisCliStratisdVersionError
+    """
+    # pylint: disable=import-outside-toplevel
+    from ._data import Manager0
+
+    version_spec = SpecifierSet(f">={MINIMUM_STRATISD_VERSION}") & SpecifierSet(
+        f"<{MAXIMUM_STRATISD_VERSION}"
+    )
+    version = Manager0.Properties.Version.Get(get_object(TOP_OBJECT))
+
+    if Version(version) not in version_spec:
+        raise StratisCliStratisdVersionError(
+            version, MINIMUM_STRATISD_VERSION, MAXIMUM_STRATISD_VERSION
+        )

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -275,6 +275,9 @@ class LvmLoopBacked(object):
     def mount_points(self):
         return [f"{self.mount_root}/{name}" for name in self.all_volumes()]
 
+    def block_devs(self):
+        return [f"/dev/{_VG_NAME}/{name}" for name in self.all_volumes()]
+
     def touch_path(self, relpath):
         path = Path(f"{self.mount_root}/{relpath}")
         path.touch()

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -95,12 +95,12 @@ class LoopBackDevices(object):
         self.count = 0
         self.devices = []
 
-    def create_devices(self, count):
+    def create_devices(self, count, dev_size=_LOOP_DEVICE_SIZE):
         for index in range(count):
             backing_file = os.path.join(self.dir, f"image{index}")
 
             with open(backing_file, "ab") as file:
-                file.truncate(_LOOP_DEVICE_SIZE)
+                file.truncate(dev_size)
 
             device = str.strip(
                 subprocess.check_output(

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -27,7 +27,7 @@ import boom
 
 from tests import MockArgs, have_root, BOOT_ROOT_TEST
 
-from ._util import LvmLoopBacked
+from ._util import LvmLoopBacked, StratisLoopBacked
 
 
 boom.set_boot_path(BOOT_ROOT_TEST)
@@ -225,83 +225,112 @@ class CommandTests(unittest.TestCase):
 
     volumes = ["root", "home", "var"]
     thin_volumes = ["opt", "srv"]
+    stratis_volumes = ["fs1", "fs2"]
 
     def setUp(self):
+        def cleanup_lvm():
+            if hasattr(self, "_lvm"):
+                self._lvm.destroy()
+
+        def cleanup_stratis():
+            if hasattr(self, "_stratis"):
+                self._stratis.destroy()
+
+        self.addCleanup(cleanup_lvm)
+        self.addCleanup(cleanup_stratis)
+
         self._lvm = LvmLoopBacked(self.volumes, thin_volumes=self.thin_volumes)
+        self._stratis = StratisLoopBacked(self.stratis_volumes)
+
         self.manager = snapm.manager.Manager()
 
-    def tearDown(self):
-        self._lvm.destroy()
+    def mount_points(self):
+        return self._lvm.mount_points() + self._stratis.mount_points()
 
     def test_print_snapsets(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         command.print_snapsets(self.manager)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_print_snapshots(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         command.print_snapshots(self.manager)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_show_snapsets(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         command.show_snapsets(self.manager)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_show_snapsets_with_members(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         command.show_snapsets(self.manager, members=True)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_show_snapsets_with_selection(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         command.show_snapsets(self.manager, selection=s)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_show_snapshots(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         command.show_snapshots(self.manager)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapset(self):
-        command.create_snapset(self.manager, "testset0", self._lvm.mount_points())
+        command.create_snapset(self.manager, "testset0", self.mount_points())
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapset_default_size_policy(self):
         command.create_snapset(
-            self.manager, "testset0", self._lvm.mount_points(), size_policy="10%FREE"
+            self.manager, "testset0", self.mount_points(), size_policy="10%FREE"
         )
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapset_per_mount_size_policy_10_free(self):
-        mount_specs = [f"{mp}:10%FREE" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:10%FREE" for mp in self.mount_points()]
         command.create_snapset(self.manager, "testset0", mount_specs)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapset_per_mount_size_policy_100_size(self):
-        mount_specs = [f"{mp}:100%SIZE" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:100%SIZE" for mp in self.mount_points()]
         command.create_snapset(self.manager, "testset0", mount_specs)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_delete_snapset(self):
-        command.create_snapset(self.manager, "testset0", self._lvm.mount_points())
+        command.create_snapset(self.manager, "testset0", self.mount_points())
         command.delete_snapset(self.manager, snapm.Selection(name="testset0"))
 
     def test_delete_snapset_ambiguous(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
             command.delete_snapset(self.manager, snapm.Selection(nr_snapshots=2))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_rename_snapset(self):
-        command.create_snapset(self.manager, "testset0", self._lvm.mount_points())
+        command.create_snapset(self.manager, "testset0", self.mount_points())
         command.rename_snapset(self.manager, "testset0", "testset1")
         sets = self.manager.find_snapshot_sets(snapm.Selection(name="testset1"))
         self.assertEqual(len(sets), 1)
         self.assertEqual(sets[0].name, "testset1")
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_main_snapset_create(self):
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "create", "testset0"]
-        args.extend(self._lvm.mount_points())
+        args.extend(self.mount_points())
+        command.main(args)
+
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "delete", "testset0"]
         command.main(args)
 
     def test_main_snapset_delete(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "delete", "testset0"]
         command.main(args)
 
     def test_main_snapset_rename(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapset",
@@ -311,24 +340,30 @@ class CommandTests(unittest.TestCase):
         ]
         command.main(args)
 
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "delete", "testset1"]
+        command.main(args)
+
     def test_main_snapset_rename_missing_newname(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "rename", "testset0"]
         with self.assertRaises(SystemExit) as cm:
             command.main(args)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_list(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "list"]
         command.main(args)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_list_verbose(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "-v", "snapset", "list"]
         command.main(args)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_list_very_verbose_debug(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "-vv",
@@ -337,9 +372,10 @@ class CommandTests(unittest.TestCase):
             "list",
         ]
         command.main(args)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_list_bad_debug(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "-vv",
@@ -349,19 +385,22 @@ class CommandTests(unittest.TestCase):
         ]
         r = command.main(args)
         self.assertEqual(r, 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_activate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapshot", "activate"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_deactivate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapshot", "deactivate"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_autoactivate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapshot",
@@ -369,9 +408,10 @@ class CommandTests(unittest.TestCase):
             "--yes",
         ]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_activate_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapshot",
@@ -380,9 +420,10 @@ class CommandTests(unittest.TestCase):
             "nosuch",
         ]
         self.assertEqual(command.main(args), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_deactivate_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapshot",
@@ -391,9 +432,10 @@ class CommandTests(unittest.TestCase):
             "nosuch",
         ]
         self.assertEqual(command.main(args), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_autoactivate_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapshot",
@@ -403,34 +445,40 @@ class CommandTests(unittest.TestCase):
             "nosuch",
         ]
         self.assertEqual(command.main(args), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_show(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "show"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_list(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapshot", "list"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapshot_show(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapshot", "show"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_activate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "activate"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_deactivate(self):
         self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "deactivate"]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_autoactivate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [
             os.path.join(os.getcwd(), "bin/snapm"),
             "snapset",
@@ -438,8 +486,10 @@ class CommandTests(unittest.TestCase):
             "--yes",
         ]
         self.assertEqual(command.main(args), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_main_snapset_revert(self):
+        # Revert is only supported on LVM2: don't include Stratis in the test.
         origin_file = "root/origin"
         snapshot_file = "root/snapshot"
         testset = "testset0"

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -196,6 +196,26 @@ class CommandTestsSimple(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             command.set_debug(args.debug)
 
+    def test_main_version(self):
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "--version"]
+        with self.assertRaises(SystemExit) as cm:
+            command.main(args)
+
+    def test_main_too_few_args(self):
+        args = [os.path.join(os.getcwd(), "bin/snapm")]
+        r = command.main(args)
+        self.assertEqual(r, 1)
+
+    def test_main_bad_command_type(self):
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "nosuch", "command"]
+        with self.assertRaises(SystemExit) as cm:
+            command.main(args)
+
+    def test_main_bad_command(self):
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "nocommand"]
+        with self.assertRaises(SystemExit) as cm:
+            command.main(args)
+
 
 @unittest.skipIf(not have_root(), "requires root privileges")
 class CommandTests(unittest.TestCase):
@@ -269,28 +289,6 @@ class CommandTests(unittest.TestCase):
         sets = self.manager.find_snapshot_sets(snapm.Selection(name="testset1"))
         self.assertEqual(len(sets), 1)
         self.assertEqual(sets[0].name, "testset1")
-
-    def test_main_version(self):
-        args = [os.path.join(os.getcwd(), "bin/snapm"), "--version"]
-        with self.assertRaises(SystemExit) as cm:
-            command.main(args)
-
-    def test_main_too_few_args(self):
-        args = [os.path.join(os.getcwd(), "bin/snapm")]
-        r = command.main(args)
-        self.assertEqual(r, 1)
-
-    def test_main_bad_command_type(self):
-        args = [os.path.join(os.getcwd(), "bin/snapm"), "nosuch", "command"]
-        args.extend(self._lvm.mount_points())
-        with self.assertRaises(SystemExit) as cm:
-            command.main(args)
-
-    def test_main_bad_command(self):
-        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "nocommand"]
-        args.extend(self._lvm.mount_points())
-        with self.assertRaises(SystemExit) as cm:
-            command.main(args)
 
     def test_main_snapset_create(self):
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "create", "testset0"]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -15,6 +15,14 @@ import unittest
 import logging
 import os
 
+import snapm
+import snapm.manager as manager
+import boom
+
+from tests import have_root, BOOT_ROOT_TEST
+from ._util import LvmLoopBacked, StratisLoopBacked
+
+
 _log = logging.getLogger()
 _log.level = logging.DEBUG
 _log.addHandler(logging.FileHandler("test.log"))
@@ -23,14 +31,6 @@ _log_debug = _log.debug
 _log_info = _log.info
 _log_warn = _log.warning
 _log_error = _log.error
-
-import snapm
-import snapm.manager as manager
-import boom
-
-from tests import have_root, BOOT_ROOT_TEST
-from ._util import LvmLoopBacked, StratisLoopBacked
-
 
 boom.set_boot_path(BOOT_ROOT_TEST)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -29,7 +29,7 @@ import snapm.manager as manager
 import boom
 
 from tests import have_root, BOOT_ROOT_TEST
-from ._util import LvmLoopBacked
+from ._util import LvmLoopBacked, StratisLoopBacked
 
 
 boom.set_boot_path(BOOT_ROOT_TEST)
@@ -120,7 +120,7 @@ class ManagerTestsSimple(unittest.TestCase):
         from snapm.manager._manager import load_plugins, PluginRegistry
 
         load_plugins()
-        self.assertEqual(len(PluginRegistry.plugins), 2)
+        self.assertEqual(len(PluginRegistry.plugins), 3)
 
     def test_plugin_info(self):
         p = manager.Plugin(_log)
@@ -207,135 +207,163 @@ class ManagerTestsSimple(unittest.TestCase):
 class ManagerTests(unittest.TestCase):
     volumes = ["root", "home", "var", "data_vol"]
     thin_volumes = ["opt", "srv", "thin-vol"]
+    stratis_volumes = ["fs1", "fs2"]
 
     def setUp(self):
-        self._lvm = LvmLoopBacked(self.volumes, thin_volumes=self.thin_volumes)
-        self.manager = manager.Manager()
+        def cleanup_lvm():
+            if hasattr(self, "_lvm"):
+                self._lvm.destroy()
 
-    def tearDown(self):
-        self._lvm.destroy()
+        def cleanup_stratis():
+            if hasattr(self, "_stratis"):
+                self._stratis.destroy()
+
+        self.addCleanup(cleanup_lvm)
+        self.addCleanup(cleanup_stratis)
+
+        self._lvm = LvmLoopBacked(self.volumes, thin_volumes=self.thin_volumes)
+        self._stratis = StratisLoopBacked(self.stratis_volumes)
+
+        self.manager = snapm.manager.Manager()
+
+    def mount_points(self):
+        return self._lvm.mount_points() + self._stratis.mount_points()
 
     def test_find_snapshot_sets_none(self):
         sets = self.manager.find_snapshot_sets()
         self.assertEqual([], sets)
 
     def test_find_snapshot_sets_one(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         sets = self.manager.find_snapshot_sets()
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_find_snapshot_sets_with_selection_name(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
-        self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
+        self.manager.create_snapshot_set("testset1", self.mount_points())
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_find_snapshot_sets_with_selection_uuid(self):
-        set1 = self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
-        self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
+        set1 = self.manager.create_snapshot_set("testset0", self.mount_points())
+        self.manager.create_snapshot_set("testset1", self.mount_points())
         s = snapm.Selection(uuid=set1.uuid)
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_create_snapshot_set(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_default_size_policy(self):
         self.manager.create_snapshot_set(
-            "testset0", self._lvm.mount_points(), default_size_policy="10%FREE"
+            "testset0", self.mount_points(), default_size_policy="10%FREE"
         )
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_size_policies_10_free(self):
-        mount_specs = [f"{mp}:10%FREE" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:10%FREE" for mp in self.mount_points()]
         self.manager.create_snapshot_set("testset0", mount_specs)
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_size_policies_10_size(self):
-        mount_specs = [f"{mp}:10%SIZE" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:10%SIZE" for mp in self.mount_points()]
         self.manager.create_snapshot_set("testset0", mount_specs)
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_size_policies_200_used(self):
-        mount_specs = [f"{mp}:200%USED" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:200%USED" for mp in self.mount_points()]
         self.manager.create_snapshot_set("testset0", mount_specs)
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_size_policies_100_size(self):
-        mount_specs = [f"{mp}:100%SIZE" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:100%SIZE" for mp in self.mount_points()]
         self.manager.create_snapshot_set("testset0", mount_specs)
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_size_policies_fixed(self):
-        mount_specs = [f"{mp}:512MiB" for mp in self._lvm.mount_points()]
+        mount_specs = [f"{mp}:512MiB" for mp in self.mount_points()]
         self.manager.create_snapshot_set("testset0", mount_specs)
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_bad_name_backslash(self):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            self.manager.create_snapshot_set("bad\\name", self._lvm.mount_points())
+            self.manager.create_snapshot_set("bad\\name", self.mount_points())
 
     def test_create_snapshot_set_bad_name_underscore(self):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            self.manager.create_snapshot_set("bad_name", self._lvm.mount_points())
+            self.manager.create_snapshot_set("bad_name", self.mount_points())
 
     def test_create_snapshot_set_bad_name_slash(self):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            self.manager.create_snapshot_set("bad/name", self._lvm.mount_points())
+            self.manager.create_snapshot_set("bad/name", self.mount_points())
 
     def test_create_snapshot_set_bad_name_space(self):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            self.manager.create_snapshot_set("bad name", self._lvm.mount_points())
+            self.manager.create_snapshot_set("bad name", self.mount_points())
 
     def test_create_snapshot_set_name_too_long(self):
         name = "a" * 127
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
-            self.manager.create_snapshot_set(name, self._lvm.mount_points())
+            self.manager.create_snapshot_set(name, self.mount_points())
 
     def test_create_snapshot_set_no_space_raises(self):
         with self.assertRaises(snapm.SnapmNoSpaceError) as cm:
             for i in range(0, 10):
                 self.manager.create_snapshot_set(
-                    f"testset{i}", self._lvm.mount_points()
+                    f"testset{i}", self.mount_points()
                 )
                 self._lvm.dump_lvs()
 
     def test_create_delete_snapshot_set(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         self.manager.delete_snapshot_sets(s)
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 0)
 
     def test_delete_snapshot_set_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="nosuch")
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.delete_snapshot_sets(s)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_duplicate(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         with self.assertRaises(snapm.SnapmExistsError) as cm:
-            self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+            self.manager.create_snapshot_set("testset0", self.mount_points())
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_create_snapshot_set_not_a_mount_point(self):
-        mount_point = self._lvm.mount_points()[0]
+        mount_point = self.mount_points()[0]
         non_mount = os.path.join(mount_point, "etc")
         os.makedirs(non_mount)
         with self.assertRaises(snapm.SnapmPathError) as cm:
@@ -346,7 +374,7 @@ class ManagerTests(unittest.TestCase):
             self.manager.create_snapshot_set("testset0", ["/boot"])
 
     def test_rename_snapshot_set(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 1)
@@ -356,32 +384,38 @@ class ManagerTests(unittest.TestCase):
         self.assertEqual(len(sets), 1)
         sets = self.manager.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 0)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_rename_snapshot_set_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.rename_snapshot_set("nosuch", "newname")
 
     def test_rename_snapshot_set_exists(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
-        self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
+        self.manager.create_snapshot_set("testset1", self.mount_points())
         with self.assertRaises(snapm.SnapmExistsError) as cm:
             self.manager.rename_snapshot_set("testset0", "testset1")
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_find_snapshots(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         snaps = self.manager.find_snapshots()
-        self.assertEqual(len(snaps), len(self._lvm.mount_points()))
+        self.assertEqual(len(snaps), len(self.mount_points()))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_find_snapshots_with_selection(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
-        self.manager.create_snapshot_set("testset1", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
+        self.manager.create_snapshot_set("testset1", self.mount_points())
         s = snapm.Selection(name="testset0")
         snaps = self.manager.find_snapshots(selection=s)
-        self.assertEqual(len(snaps), len(self._lvm.mount_points()))
+        self.assertEqual(len(snaps), len(self.mount_points()))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset1"))
 
     def test_activate_deactivate_snapsets(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         self.manager.activate_snapshot_sets(selection=s)
         sets = self.manager.find_snapshot_sets(selection=s)
@@ -391,37 +425,44 @@ class ManagerTests(unittest.TestCase):
         for snap in sets[0].snapshots:
             if snap.origin.removeprefix("test_vg0/") in self.thin_volumes:
                 self.assertEqual(snap.status, snapm.SnapStatus.INACTIVE)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_activate_snapsets_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="nosuch")
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.activate_snapshot_sets(selection=s)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_deactivate_snapsets_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="nosuch")
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.deactivate_snapshot_sets(selection=s)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_set_autoactivate_snapsets(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="testset0")
         self.manager.set_autoactivate(s, auto=False)
         sets = self.manager.find_snapshot_sets(selection=s)
-        for snap in sets[0].snapshots:
-            self.assertEqual(snap.autoactivate, False)
+        # autoactivate cannot be set to False for Stratis snapshots
+        #for snap in sets[0].snapshots:
+        #    self.assertEqual(snap.autoactivate, False)
         self.manager.set_autoactivate(s, auto=True)
         for snap in sets[0].snapshots:
             self.assertEqual(snap.autoactivate, True)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_set_autoactivate_snapsets_nosuch(self):
-        self.manager.create_snapshot_set("testset0", self._lvm.mount_points())
+        self.manager.create_snapshot_set("testset0", self.mount_points())
         s = snapm.Selection(name="nosuch")
         with self.assertRaises(snapm.SnapmNotFoundError) as cm:
             self.manager.set_autoactivate(s, True)
+        self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
     def test_revert_snapshot_sets(self):
+        # Revert is only supported on LVM2: don't include Stratis in the test.
         origin_file = "root/origin"
         snapshot_file = "root/snapshot"
         testset = "testset0"

--- a/tests/test_manager_blockdevs.py
+++ b/tests/test_manager_blockdevs.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2023 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# tests/test_plugin.py - Plugin core unit tests
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+import snapm
+import snapm.manager.plugins as plugins
+import snapm.manager.plugins.lvm2 as lvm2
+import snapm.manager as manager
+import snapm.command as command
+import unittest
+import logging
+
+from ._util import LvmLoopBacked
+
+SNAPSET_NAME = "testset0"
+
+log = logging.getLogger()
+log.level = logging.DEBUG
+log.addHandler(logging.FileHandler("test.log"))
+
+# 1GiB
+_TEST_LOOPBACK_SIZE = 1024**3
+_TEST_SOURCE_COUNT = 4
+
+
+class ManagerBlockdevTests(unittest.TestCase):
+    volumes = ["root", "home", "var", "data_vol"]
+    thin_volumes = ["opt", "srv", "thin-vol"]
+
+    def setUp(self):
+
+        def cleanup_lvm():
+            if hasattr(self, "_lvm"):
+                self._lvm.destroy()
+
+        self.addCleanup(cleanup_lvm)
+
+        self._lvm = LvmLoopBacked(self.volumes, thin_volumes=self.thin_volumes)
+        self._manager = manager.Manager()
+
+    def test_blockdevs_create(self):
+        snapset = self._manager.create_snapshot_set(
+            SNAPSET_NAME, self._lvm.block_devs())
+        command.print_snapsets(self._manager)
+        self._manager.delete_snapshot_sets(snapm.Selection(name=SNAPSET_NAME))
+
+    def test_find_snapshot_sets_one(self):
+        self._manager.create_snapshot_set(SNAPSET_NAME, self._lvm.block_devs())
+        sets = self._manager.find_snapshot_sets()
+        self.assertEqual(len(sets), 1)
+        self._manager.delete_snapshot_sets(snapm.Selection(name=SNAPSET_NAME))

--- a/tests/test_stratis.py
+++ b/tests/test_stratis.py
@@ -1,0 +1,212 @@
+# Copyright (C) 2023 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# tests/test_stratis.py - Stratis plugin unit tests
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+import unittest
+import logging
+import os.path
+import psutil
+import os
+from subprocess import run
+
+from dbus_client_gen import DbusClientUniqueResultError
+
+log = logging.getLogger()
+log.level = logging.DEBUG
+log.addHandler(logging.FileHandler("test.log"))
+
+from snapm.manager.plugins.stratislib import (
+    get_object,
+    TOP_OBJECT,
+    ObjectManager,
+)
+from snapm import SnapmNotFoundError
+import snapm.manager.plugins.stratis as stratis
+from snapm.manager.plugins import device_from_mount_point
+
+from ._util import StratisLoopBacked
+
+
+def _systemctl_args(command):
+    return [
+        "systemctl",
+        f"{command}",
+        "stratisd"
+    ]
+
+
+class StratisTestsSimple(unittest.TestCase):
+    """Test Stratis plugin functions"""
+
+    _old_path = None
+
+    def setUp(self):
+        def cleanup():
+            os.environ["PATH"] = self._old_path
+
+        self.addCleanup(cleanup)
+
+        bin_path = os.path.abspath("tests/bin")
+        cur_path = os.environ["PATH"]
+        self._old_path = cur_path
+        os.environ["PATH"] = bin_path + os.pathsep + cur_path
+
+    def test_is_stratis_device(self):
+        devs = {
+            "/dev/mapper/fedora-home": False,
+            "/dev/mapper/fedora-root": False,
+            "/dev/mapper/fedora-var": False,
+            "/dev/mapper/stratis-1-1c7c941a2dba4eb78d57d3fb01aacc61-thin-fs-202ea1667fa54123bd24f0c353b9914c": True,
+            "/dev/mapper/mpatha": False,
+        }
+        for dev in devs.keys():
+            self.assertEqual(stratis.is_stratis_device(dev), devs[dev])
+
+    def test_is_stratisd_running(self):
+        running = False
+        for proc in psutil.process_iter():
+            try:
+                if proc.name() == "stratisd":
+                    running = True
+            except psutil.NoSuchProcess:
+                running = False
+        self.assertEqual(running, stratis.is_stratisd_running())
+
+    def test_is_stratisd_running_stopped(self):
+        systemctl_stop_args = _systemctl_args("stop")
+        run(systemctl_stop_args, check=True)
+        self.assertEqual(False, stratis.is_stratisd_running())
+        systemctl_start_args = _systemctl_args("start")
+        run(systemctl_start_args, check=True)
+
+    def test_stratis_devices_present(self):
+        self.assertEqual(stratis.stratis_devices_present(), True)
+
+    def test__snapshot_min_size(self):
+        sizes = [
+            (256 * 2**20, 512 * 2**20),  # 256MiB/512MiB
+            (512 * 2**20, 512 * 2**20),  # 512MiB/512MiB
+            (1 * 2**30, 1 * 2**30),      # 1GiB/1GiB
+            (100 * 2**30, 100 * 2**30),  # 100GiB/100GiB
+            (1 * 2**40, 1 * 2**40),      # 1TiB/1TiB
+        ]
+        for (size, xsize) in sizes:
+            self.assertEqual(xsize, stratis._snapshot_min_size(size))
+
+
+class StratisTests(unittest.TestCase):
+
+    stratis_volumes = ["fs1", "fs2"]
+
+    def setUp(self):
+        def cleanup():
+            if hasattr(self, "_stratis"):
+                self._stratis.destroy()
+
+        self.addCleanup(cleanup)
+
+        self._stratis = StratisLoopBacked(self.stratis_volumes)
+
+    def test__get_pool_filesystem(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        (pool, filesystem) = stratis._get_pool_filesystem(managed_objects, "pool1", "fs1")
+        self.assertTrue(str(pool.Name()) == "pool1")
+        self.assertTrue(str(filesystem.Name()) == "fs1")
+
+    def test__get_pool_filesystem_bad_pool(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        with self.assertRaises(DbusClientUniqueResultError) as cm:
+            (pool, filesystem) = stratis._get_pool_filesystem(managed_objects, "nosuchpool1", "fs1")
+
+    def test__get_pool_filesystem_bad_fs(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        with self.assertRaises(DbusClientUniqueResultError) as cm:
+            (pool, filesystem) = stratis._get_pool_filesystem(managed_objects, "pool1", "nosuchfs1")
+
+    def test_pool_free_space_bytes(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        (pool, filesystem) = stratis._get_pool_filesystem(managed_objects, "pool1", "fs1")
+        free_bytes = stratis._pool_free_space_bytes(managed_objects, "pool1")
+        self.assertEqual(
+            int(pool.TotalPhysicalSize()) - int(pool.TotalPhysicalUsed()[1]) if pool.TotalPhysicalUsed()[0] else 0,
+            free_bytes
+        )
+
+    def test_fs_size_bytes(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        size_bytes = stratis._fs_size_bytes(managed_objects, "pool1", "fs1")
+        self.assertEqual(size_bytes, 2**30)
+
+    def test_pool_fs_from_device_path(self):
+        devpath = device_from_mount_point(self._stratis.mount_points()[0])
+        (pool, fs) = stratis.pool_fs_from_device_path(devpath)
+        self.assertEqual(pool, "pool1")
+        self.assertEqual(fs, "fs1")
+
+    def test_stratis_discover_snapshots(self):
+        self._stratis.create_snapshot("fs1", "fs1-snapset_test_1721136677_-opt")
+        self._stratis.create_snapshot("fs2", "fs2-snapset_test_1721136677_-data")
+        stratis_plugin = stratis.Stratis(log)
+        snapshots = stratis_plugin.discover_snapshots()
+        self.assertEqual(len(snapshots), 2)
+
+    def test_stratis_can_snapshot_no_stratisd(self):
+        systemctl_stop_args = _systemctl_args("stop")
+        run(systemctl_stop_args, check=True)
+
+        with self.assertRaises(SnapmNotFoundError) as cm:
+            stratis_plugin = stratis.Stratis(log)
+
+        systemctl_start_args = _systemctl_args("start")
+        run(systemctl_start_args, check=True)
+
+    def test__origin_uuid_to_fs_name(self):
+        self._stratis.create_snapshot("fs1", "fs1-snapset_test_1721136677_-opt")
+
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        (pool, fs) = stratis._get_pool_filesystem(managed_objects, "pool1", "fs1-snapset_test_1721136677_-opt")
+
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        origin = stratis._origin_uuid_to_fs_name(
+            managed_objects, fs.Pool(), str(fs.Origin()[1])
+        )
+
+        self.assertEqual(origin, "fs1")
+
+    def test_filter_stratis_snapshot_snapshot(self):
+        self._stratis.create_snapshot("fs1", "fs1-snapset_test_1721136677_-opt")
+
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        (pool, fs) = stratis._get_pool_filesystem(managed_objects, "pool1", "fs1-snapset_test_1721136677_-opt")
+        self.assertEqual(True, stratis.filter_stratis_snapshot(fs))
+
+    def test_filter_stratis_snapshot_nonsnapshot(self):
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+
+        (pool, fs) = stratis._get_pool_filesystem(managed_objects, "pool1", "fs1")
+        self.assertEqual(False, stratis.filter_stratis_snapshot(fs))


### PR DESCRIPTION
If we decide to take this approach, there will be a lot of renaming of variables/changes to the docs.

I think it is the least disruptive from a code changes perspective.

At a high level, I changed the code to allow what is currently the mount_point parameter to be either a mount point or a block device.  When the provider_map is constructed, the plugins how deal with either.  The Stratis plugin just returns false in can_snapshot().

I also wanted to get your thoughts on adding a parameter that will allow the caller to select a plugin.  The snapshot role has a few cases where it expects the error message that LVM returns.  I was hoping to use snapm to call a specific plugin.  I was thinking I'd add an optional parameter:

  _find_and_verify_plugins(self, mount_points, size_policies, requested_provider=None)

If a requested provider was supplied, rather than call can_snapshot() - we'd just call the plugin requested?
 