### PR TITLE
tests: temporarily exclude CentOS from test_boot.is_redhat() check

### DIFF
--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -39,7 +39,10 @@ _VAR_TMP = "/var/tmp"
 
 
 def is_redhat():
-    return os.path.exists("/etc/redhat-release")
+    # Exclude CentOS for now until the fix for boom-boot #59 is available
+    # in the CentOS repositories.
+    return (os.path.exists("/etc/redhat-release")
+            and not os.path.exists("/etc/centos-release"))
 
 
 class BootTestsSimple(unittest.TestCase):


### PR DESCRIPTION
The current version of boom-boot in CentOS Stream does not support automatic --uname-pattern for CentOS installations:

```
  # boom profile create --from-host
  Could not determine uname pattern for 'CentOS Stream'
```

Exclude CentOS temporarily from the profile auto-creation test until https://github.com/snapshotmanager/boom-boot/issues/59 is fixed and available in the CentOS repos.