### PR TITLE
Improve KeyboardInterrupt handling

### DIFF
--- a/snapm/command.py
+++ b/snapm/command.py
@@ -1117,6 +1117,7 @@ def setup_logging(cmd_args):
     elif cmd_args.verbose and cmd_args.verbose > 0:
         level = logging.INFO
     snapm_log = logging.getLogger("snapm")
+    snapm_log.setLevel(level)
     formatter = logging.Formatter("%(levelname)s - %(message)s")
     if _CONSOLE_HANDLER not in snapm_log.handlers:
         _CONSOLE_HANDLER = logging.StreamHandler()
@@ -1551,6 +1552,8 @@ def main(args):
         try:
             status = cmd_args.func(cmd_args)
         # pylint: disable=broad-except
+        except KeyboardInterrupt:
+            _log_error("Exiting on user cancel")
         except Exception as err:
             _log_error("Command failed: %s", err)
 

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -476,30 +476,9 @@ def create_snapset(manager, name, sources, size_policy=None, boot=False, revert=
     :param boot: Create a boot entry for this snapshot set.
     :param revert: Create a revert boot entry for this snapshot set.
     """
-    snapset = manager.create_snapshot_set(
-        name, sources, default_size_policy=size_policy
+    return manager.create_snapshot_set(
+        name, sources, default_size_policy=size_policy, boot=boot, revert=revert
     )
-
-    # Snapshot sets must be active to create boot entries.
-    if boot or revert:
-        select = Selection(name=snapset.name)
-        manager.activate_snapshot_sets(select)
-
-    if boot:
-        try:
-            manager.create_snapshot_set_boot_entry(name=snapset.name)
-        except (OSError, ValueError, TypeError) as err:
-            _log_error("Failed to create snapshot set boot entry: %s", err)
-            manager.delete_snapshot_sets(select)
-            return None
-    if revert:
-        try:
-            manager.create_snapshot_set_revert_entry(name=snapset.name)
-        except (OSError, ValueError, TypeError) as err:
-            _log_error("Failed to create snapshot set revert boot entry: %s", err)
-            manager.delete_snapshot_sets(select)
-            return None
-    return snapset
 
 
 def delete_snapset(manager, selection):

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -1049,31 +1049,9 @@ class Manager:
                 f"Could not find snapshot sets matching {selection}"
             )
         for snapset in sets:
-            if any(snapshot.snapshot_mounted for snapshot in snapset.snapshots):
-                raise SnapmBusyError(
-                    f"Snapshots from snapshot set {snapset.name} are mounted: cannot delete"
-                )
-            if snapset.status == SnapStatus.REVERTING:
-                _log_error(
-                    "Cannot operate on reverting snapshot set '%s'", snapset.name
-                )
-                raise SnapmBusyError(f"Failed to delete snapshot set {snapset.name}")
             delete_snapset_boot_entry(snapset)
             delete_snapset_revert_entry(snapset)
-            for snapshot in snapset.snapshots.copy():
-                try:
-                    snapshot.delete()
-                    snapset.snapshots.remove(snapshot)
-                except SnapmError as err:
-                    _log_error(
-                        "Failed to delete snapshot set member %s: %s",
-                        snapshot.name,
-                        err,
-                    )
-                    raise SnapmPluginError(
-                        f"Could not delete all snapshots for set {snapset.name}"
-                    ) from err
-
+            snapset.delete()
             self.snapshot_sets.remove(snapset)
             self.by_name.pop(snapset.name)
             self.by_uuid.pop(snapset.uuid)

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -26,6 +26,7 @@ import inspect
 import os
 
 import snapm.manager.plugins
+from snapm.manager.signals import suspend_signals
 from snapm.manager.boot import (
     BootCache,
     create_snapset_boot_entry,
@@ -631,6 +632,7 @@ class Manager:
     by_name = {}
     by_uuid = {}
 
+    @suspend_signals
     def __init__(self):
         self.plugins = []
         self.snapshot_sets = []
@@ -870,6 +872,7 @@ class Manager:
                 )
 
     # pylint: disable=too-many-branches,too-many-locals
+    @suspend_signals
     def create_snapshot_set(self, name, source_specs, default_size_policy=None):
         """
         Create a snapshot set of the supplied mount points with the name
@@ -969,6 +972,7 @@ class Manager:
         self.snapshot_sets.append(snapset)
         return snapset
 
+    @suspend_signals
     def rename_snapshot_set(self, old_name, new_name):
         """
         Rename snapshot set ``old_name`` as ``new_name``.
@@ -1031,6 +1035,7 @@ class Manager:
         self.snapshot_sets.append(new_snapset)
         return new_snapset
 
+    @suspend_signals
     def delete_snapshot_sets(self, selection):
         """
         Remove snapshot sets matching selection criteria ``selection``.
@@ -1077,6 +1082,7 @@ class Manager:
         return deleted
 
     # pylint: disable=too-many-branches
+    @suspend_signals
     def resize_snapshot_set(
         self, source_specs, name=None, uuid=None, default_size_policy=None
     ):
@@ -1145,6 +1151,7 @@ class Manager:
         for provider in providers:
             provider.end_transaction()
 
+    @suspend_signals
     def revert_snapshot_set(self, name=None, uuid=None):
         """
         Revert snapshot set named ``name`` or having UUID ``uuid``.
@@ -1213,6 +1220,7 @@ class Manager:
             reverted += 1
         return reverted
 
+    @suspend_signals
     def activate_snapshot_sets(self, selection):
         """
         Activate snapshot sets matching selection criteria ``selection``.
@@ -1243,6 +1251,7 @@ class Manager:
             activated += 1
         return activated
 
+    @suspend_signals
     def deactivate_snapshot_sets(self, selection):
         """
         Deactivate snapshot sets matching selection criteria ``selection``.
@@ -1273,6 +1282,7 @@ class Manager:
             deactivated += 1
         return deactivated
 
+    @suspend_signals
     def set_autoactivate(self, selection, auto=False):
         """
         Set autoactivation state for snapshot sets matching selection criteria
@@ -1294,6 +1304,7 @@ class Manager:
             changed += 1
         return changed
 
+    @suspend_signals
     def create_snapshot_set_boot_entry(self, name=None, uuid=None):
         """
         Create a snapshot boot entry for the specified snapshot set.
@@ -1316,6 +1327,7 @@ class Manager:
         create_snapset_boot_entry(snapset)
         self._boot_cache.refresh_cache()
 
+    @suspend_signals
     def create_snapshot_set_revert_entry(self, name=None, uuid=None):
         """
         Create a revert boot entry for the specified snapshot set.

--- a/snapm/manager/signals.py
+++ b/snapm/manager/signals.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2025 Red Hat, Inc., Bryn M. Reeves <bmr@redhat.com>
+#
+# snapm/manager/signals.py - Snapshot Manager signal handling
+#
+# This file is part of the snapm project.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+"""
+Helpers for blocking and unblocking signal delivery.
+"""
+from signal import SIG_BLOCK, SIG_UNBLOCK, SIGINT, SIGTERM, pthread_sigmask
+from functools import wraps
+import logging
+
+_log = logging.getLogger(__name__)
+_log_debug = _log.debug
+
+_to_block = {SIGINT, SIGTERM}
+
+
+def block_signals():
+    """
+    Block termination signals before entering critical section.
+    """
+    _log_debug("Blocking termination signals %s", _to_block)
+    pthread_sigmask(SIG_BLOCK, _to_block)
+
+
+def unblock_signals():
+    """
+    Unblock and deliver termination signals after leaving critical section.
+    """
+    _log_debug("Unblocking termination signals %s", _to_block)
+    pthread_sigmask(SIG_UNBLOCK, _to_block)
+
+
+def suspend_signals(func):
+    """
+    Decorator to wrap functions that implement a critical section.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        block_signals()
+        try:
+            ret = func(*args, **kwargs)
+        finally:
+            unblock_signals()
+        return ret
+
+    return wrapper


### PR DESCRIPTION
Prevent Ctrl-C from interrupting critical sections in `Manager` methods by blocking and unblocking `SIGINT` and `SIGTERM` via a function decorator.