### PR TITLE
Refactor Manager methods and move logic to SnapshotSet

### DIFF
--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -638,6 +638,7 @@ class SnapStatus(Enum):
         return "Invalid"
 
 
+# pylint: disable=too-many-public-methods
 class SnapshotSet:
     """
     Representation of a set of snapshots taken at the same point
@@ -946,6 +947,42 @@ class SnapshotSet:
                 raise SnapmPluginError(
                     f"Could not delete all snapshots for set {self.name}"
                 ) from err
+
+    def revert(self):
+        """
+        Initiate a revert operation on this ``SnapshotSet``.
+
+        :raises: ``SnapmPluginError`` if a plugin fails to perform the
+                 requested operation.
+        """
+        revert_entry = self.revert_entry
+        mounted = self.mounted
+        name = self.name
+
+        # Perform revert operation on all snapshots
+        for snapshot in self.snapshots:
+            try:
+                snapshot.revert()
+            except SnapmError as err:
+                _log_error(
+                    "Failed to revert snapshot set member %s: %s",
+                    snapshot.name,
+                    err,
+                )
+                raise SnapmPluginError(
+                    f"Could not revert all snapshots for set {self.name}"
+                ) from err
+        if mounted:
+            _log_warn(
+                "Snaphot set %s is in use: reboot required to complete revert",
+                name,
+            )
+            if revert_entry:
+                _log_warn(
+                    "Boot into '%s' to continue",
+                    revert_entry.title,
+                )
+
 
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -645,6 +645,14 @@ class SnapshotSet:
     in time and managed as a group.
     """
 
+    def _link_snapshots(self):
+        self._by_mount_point = {}
+        self._by_origin = {}
+        for snapshot in self._snapshots:
+            if snapshot.mount_point:
+                self._by_mount_point[snapshot.mount_point] = snapshot
+            self._by_origin[snapshot.origin] = snapshot
+
     def __init__(self, name, timestamp, snapshots):
         """
         Initialise a new ``SnapshotSet`` object.
@@ -657,14 +665,9 @@ class SnapshotSet:
         self._uuid = uuid5(NAMESPACE_SNAPSHOT_SET, name + str(timestamp))
         self._timestamp = timestamp
         self._snapshots = snapshots
-        self._by_mount_point = {}
-        self._by_origin = {}
+        self._link_snapshots()
         self.boot_entry = None
         self.revert_entry = None
-        for snapshot in self._snapshots:
-            if snapshot.mount_point:
-                self._by_mount_point[snapshot.mount_point] = snapshot
-            self._by_origin[snapshot.origin] = snapshot
 
     def __str__(self):
         """
@@ -953,6 +956,7 @@ class SnapshotSet:
         self._name = new_name
         self._uuid = uuid5(NAMESPACE_SNAPSHOT_SET, self.name + str(self.timestamp))
         self._snapshots = new_snapshots
+        self._link_snapshots()
 
     def delete(self):
         """

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -983,6 +983,45 @@ class SnapshotSet:
                     revert_entry.title,
                 )
 
+    def activate(self):
+        """
+        Attempt to activate all members of this ``SnapshotSet``.
+
+        :raises: ``SnapmPluginError`` if a plugin fails to perform the
+                 requested operation.
+        """
+        for snapshot in self.snapshots:
+            try:
+                snapshot.activate()
+            except SnapmError as err:
+                _log_error(
+                    "Failed to activate snapshot set member %s: %s",
+                    snapshot.name,
+                    err,
+                )
+                raise SnapmPluginError(
+                    f"Could not activate all snapshots for set {self.name}"
+                ) from err
+
+    def deactivate(self):
+        """
+        Attempt to deactivate all members of this ``SnapshotSet``.
+
+        :raises: ``SnapmPluginError`` if a plugin fails to perform the
+                 requested operation.
+        """
+        for snapshot in self.snapshots:
+            try:
+                snapshot.deactivate()
+            except SnapmError as err:
+                _log_error(
+                    "Failed to deactivate snapshot set member %s: %s",
+                    snapshot.name,
+                    err,
+                )
+                raise SnapmPluginError(
+                    f"Could not deactivate all snapshots for set {self.name}"
+                ) from err
 
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -1209,19 +1209,7 @@ class Manager:
             )
         for snapset in sets:
             _check_snapset_status(snapset, "activate")
-
-            for snapshot in snapset.snapshots:
-                try:
-                    snapshot.activate()
-                except SnapmError as err:
-                    _log_error(
-                        "Failed to activate snapshot set member %s: %s",
-                        snapshot.name,
-                        err,
-                    )
-                    raise SnapmPluginError(
-                        f"Could not activate all snapshots for set {snapset.name}"
-                    ) from err
+            snapset.activate()
             activated += 1
         return activated
 
@@ -1240,19 +1228,7 @@ class Manager:
             )
         for snapset in sets:
             _check_snapset_status(snapset, "deactivate")
-
-            for snapshot in snapset.snapshots:
-                try:
-                    snapshot.deactivate()
-                except SnapmError as err:
-                    _log_error(
-                        "Failed to deactivate snapshot set member %s: %s",
-                        snapshot.name,
-                        err,
-                    )
-                    raise SnapmPluginError(
-                        f"Could not deactivate all snapshots for set {snapset.name}"
-                    ) from err
+            snapset.deactivate()
             deactivated += 1
         return deactivated
 

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -1169,33 +1169,7 @@ class Manager:
         # Snapshot boot entry becomes invalid as soon as revert is initiated.
         delete_snapset_boot_entry(snapset)
 
-        revert_entry = snapset.revert_entry
-        mounted = snapset.mounted
-        name = snapset.name
-
-        # Perform revert operation on all snapshots
-        for snapshot in snapset.snapshots:
-            try:
-                snapshot.revert()
-            except SnapmError as err:
-                _log_error(
-                    "Failed to revert snapshot set member %s: %s",
-                    snapshot.name,
-                    err,
-                )
-                raise SnapmPluginError(
-                    f"Could not revert all snapshots for set {snapset.name}"
-                ) from err
-        if mounted:
-            _log_warn(
-                "Snaphot set %s is in use: reboot required to complete revert",
-                name,
-            )
-            if revert_entry:
-                _log_warn(
-                    "Boot into '%s' to continue",
-                    revert_entry.title,
-                )
+        snapset.revert()
 
         self._boot_cache.refresh_cache()
         return snapset


### PR DESCRIPTION
Push logic for manipulating snapshot sets down from the corresponding `Manager` methods into new `SnapshotSet` methods. This simplifies the `Manager` implementation and separates out the handling of the manager state from operations on individual snapshot sets.