### PR TITLE
tests: switch GitHub workflows over to Stratis 3.8.0

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           toolchain: stable
       - name: Check out stratisd
-        run: git clone https://github.com/stratis-storage/stratisd -b rebase-3.6.0
+        run: git clone https://github.com/stratis-storage/stratisd -b stratisd-v3.8.0
         working-directory: /var/tmp
       - name: Build stratisd
         run: make build-all
@@ -85,7 +85,7 @@ jobs:
           sudo systemctl enable --now stratisd
         working-directory: /var/tmp/stratisd
       - name: Check out stratis-cli
-        run: git clone https://github.com/stratis-storage/stratis-cli -b rebase-3.6.0
+        run: git clone https://github.com/stratis-storage/stratis-cli -b v3.8.0
         working-directory: /var/tmp
       - name: Install stratis-cli
         run: sudo pip install -v .


### PR DESCRIPTION
Update tests to use the newly released Stratis v3.8.0:

  https://github.com/stratis-storage/stratisd/releases/tag/stratisd-v3.8.0
  https://github.com/stratis-storage/stratis-cli/releases/tag/v3.8.0

Resolves: #113.