### PR TITLE
snapm: raise SnapmNotFoundError if source path does not exist

### DIFF
--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -665,6 +665,10 @@ class Manager:
 
         # Find provider plugins for sources
         for source in sources:
+            if not exists(source):
+                _log_error("No such file or directory: %s", source)
+                raise SnapmNotFoundError(f"Source path '{source}' does not exist")
+
             _log_debug(
                 "Probing plugins for %s with size policy %s",
                 source,


### PR DESCRIPTION
Currently Manager.create_snapshot_set() fails with FileNotFoundError when a source path is non-existent:

ERROR - Command failed: [Errno 2] No such file or directory: '/not/a/mount/point'

FileNotFoundError: [Errno 2] No such file or directory: '/dev/fedora/nosuch'

Vs.

ERROR - No such file or directory: /not/a/mount/point
ERROR - Command failed: Source path '/not/a/mount/point' does not exist

SnapmNotFoundError: Source path '/not/a/mount/point' does not exist

Fixes: #118