### PR TITLE
Add template systemd units for scheduler

### DIFF
--- a/systemd/snapm-create@.service
+++ b/systemd/snapm-create@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Create %I snapshot sets
+Documentation=man:snapm(8) man:snapm-conf(5)
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=snapm snapset create -c %i.conf

--- a/systemd/snapm-create@.timer
+++ b/systemd/snapm-create@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Scheduled %I snapshot set creation timer
+Documentation=man:snapm(8) man:snapm-conf(5)
+
+[Timer]
+Unit=snapm-create@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/snapm-gc@.service
+++ b/systemd/snapm-gc@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Clean up %I snapshot sets
+Documentation=man:snapm(8) man:snapm-conf(5)
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=snapm schedule gc -c %i.conf

--- a/systemd/snapm-gc@.timer
+++ b/systemd/snapm-gc@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Scheduled %I snapshot set cleanup
+Documentation=man:snapm(8) man:snapm-conf(5)
+
+[Timer]
+Unit=snapm-gc@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Add two pairs of systemd units for scheduled snapshot set creation and garbage collection: each pair consists of a timer unit (that is parameterized by a drop-in file when it is instantiated), and a service unit that calls `snapm snapset create` or `snapm schedule gc` as appropriate.

Resolves: #125