### PR TITLE
snapm: introduce snapshot set level locking in Manager

### DIFF
--- a/snapm/command.py
+++ b/snapm/command.py
@@ -20,6 +20,7 @@ from os.path import basename
 from json import dumps
 from uuid import UUID
 import logging
+import os
 
 from snapm import (
     SnapmInvalidIdentifierError,
@@ -2322,6 +2323,10 @@ def main(args):
         return status
 
     setup_logging(cmd_args)
+
+    if os.geteuid() != 0:
+        _log_error("snapm must be run as the root user")
+        return status
 
     _log_debug_command("Parsed %s", " ".join(args[1:]))
 

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -1164,6 +1164,18 @@ class Manager:
         return reverted
 
     @suspend_signals
+    def activate_snapshot_set(self, name=None, uuid=None):
+        """
+        Activate snapshot set by name or uuid.
+
+        :param name: The name of the snapshot set to activate.
+        :param uuid: The UUID of the snapshot set to activate.
+        """
+        snapset = self._snapset_from_name_or_uuid(name=name, uuid=uuid)
+        _check_snapset_status(snapset, "activate")
+        snapset.activate()
+
+    @suspend_signals
     def activate_snapshot_sets(self, selection):
         """
         Activate snapshot sets matching selection criteria ``selection``.
@@ -1177,10 +1189,21 @@ class Manager:
                 f"Could not find snapshot sets matching {selection}"
             )
         for snapset in sets:
-            _check_snapset_status(snapset, "activate")
-            snapset.activate()
+            self.activate_snapshot_set(name=snapset.name)
             activated += 1
         return activated
+
+    @suspend_signals
+    def deactivate_snapshot_set(self, name=None, uuid=None):
+        """
+        Deactivate snapshot set by name or uuid.
+
+        :param name: The name of the snapshot set to deactivate.
+        :param uuid: The UUID of the snapshot set to deactivate.
+        """
+        snapset = self._snapset_from_name_or_uuid(name=name, uuid=uuid)
+        _check_snapset_status(snapset, "deactivate")
+        snapset.deactivate()
 
     @suspend_signals
     def deactivate_snapshot_sets(self, selection):
@@ -1196,8 +1219,7 @@ class Manager:
                 f"Could not find snapshot sets matching {selection}"
             )
         for snapset in sets:
-            _check_snapset_status(snapset, "deactivate")
-            snapset.deactivate()
+            self.deactivate_snapshot_set(name=snapset.name)
             deactivated += 1
         return deactivated
 

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -182,11 +182,11 @@ class BootTestsWithRoot(BootTestsBase):
     with_root = True
 
     def test_create_snapshot_boot_entry_no_id(self):
-        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+        with self.assertRaises(snapm.SnapmInvalidIdentifierError):
             self.manager.create_snapshot_set_boot_entry()
 
     def test_create_snapshot_revert_entry_no_id(self):
-        with self.assertRaises(snapm.SnapmNotFoundError) as cm:
+        with self.assertRaises(snapm.SnapmInvalidIdentifierError):
             self.manager.create_snapshot_set_revert_entry()
 
     def test_create_snapshot_boot_entry_bad_name(self):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -120,58 +120,70 @@ class CommandTestsSimple(CommandTestsBase):
 
         self.assertEqual(opts, xopts)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple(self):
         args = MockArgs()
         command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple_bad_field(self):
         args = MockArgs()
         args.options = "nosuchfield"
         command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple_debug(self):
         args = MockArgs()
         args.debug = "all"
         command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple_debug_bad_field(self):
         args = MockArgs()
         args.debug = "all"
         args.options = "nosuchfield"
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple_verbose(self):
         args = MockArgs()
         args.verbose = 1
         command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_cmd_simple_fields(self):
         args = MockArgs()
         args.options = "name,uuid"
         command._list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__list_snapshot_cmd_simple(self):
         args = MockArgs()
         command._snapshot_list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__show_cmd_simple(self):
         args = MockArgs()
         command._show_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__show_cmd_simple_verbose(self):
         args = MockArgs()
         args.verbose = 1
         command._show_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__show_snapshot_cmd_simple(self):
         args = MockArgs()
         command._snapshot_show_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test__plugin_list_cmd_simple(self):
         args = MockArgs()
         command._plugin_list_cmd(args)
 
+    @unittest.skipIf(not have_root(), "requires root privileges")
     def test_main_plugin_list(self):
         args = self.get_debug_main_args()
         args += ["plugin", "list"]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,6 +10,8 @@ import logging
 import os
 from uuid import UUID
 from json import loads
+import tempfile
+import errno
 
 
 import snapm
@@ -25,6 +27,7 @@ log = logging.getLogger()
 boom.set_boot_path(BOOT_ROOT_TEST)
 
 
+@unittest.skipIf(not have_root(), "requires root privileges")
 class ManagerTestsSimple(unittest.TestCase):
     """
     Test manager interfaces with mock callouts
@@ -107,6 +110,43 @@ class ManagerTestsSimple(unittest.TestCase):
         s = snapm.Selection(nr_snapshots=5)
         sets = m.find_snapshot_sets(selection=s)
         self.assertEqual(len(sets), 2)
+
+    def test__escape_unescape_path(self):
+        paths = (
+            ("/", "\\x2f"),
+            ("/home", "\\x2fhome"),
+            ("/foo/bar/baz", "\\x2ffoo\\x2fbar\\x2fbaz"),
+            ("//quux", "\\x2f\\x2fquux"),
+        )
+        for path, xescape in paths:
+            with self.subTest(path=path):
+                self.assertEqual(manager._manager._escape_path(path), xescape)
+                self.assertEqual(manager._manager._unescape_path(xescape), path)
+
+    def test__check_lock_dir(self):
+        _manager = manager._manager
+        _orig_lock_dir = _manager._SNAPSET_LOCK_DIR
+        self.addCleanup(setattr, _manager, "_SNAPSET_LOCK_DIR", _orig_lock_dir)
+        with tempfile.TemporaryDirectory(suffix="_test_run_lock", dir="/tmp") as tempdir:
+            _manager._SNAPSET_LOCK_DIR = str(tempdir) + _orig_lock_dir
+            self.assertEqual(_manager._check_lock_dir(), _manager._SNAPSET_LOCK_DIR)
+            st = os.stat(_manager._SNAPSET_LOCK_DIR)
+            self.assertEqual(st.st_mode & 0o777, _manager._SNAPSET_LOCK_DIR_MODE)
+
+    def test__lock_unlock_snapshot_set(self):
+        _manager = manager._manager
+        _orig_lock_dir = _manager._SNAPSET_LOCK_DIR
+        self.addCleanup(setattr, _manager, "_SNAPSET_LOCK_DIR", _orig_lock_dir)
+        with tempfile.TemporaryDirectory(suffix="_test_run_lock", dir="/tmp") as tempdir:
+            _manager._SNAPSET_LOCK_DIR = str(tempdir) + _orig_lock_dir
+            lockdir = _manager._check_lock_dir()
+            fd = _manager._lock_snapshot_set(lockdir, "foo")
+            self.assertGreater(fd, 0)
+            self.assertTrue(os.path.exists(os.path.join(lockdir, "foo.lock")))
+            _manager._unlock_snapshot_set(lockdir, "foo", fd)
+            with self.assertRaises(OSError) as cm:
+                os.dup(fd)
+            self.assertEqual(cm.exception.errno, errno.EBADF)
 
 
 @unittest.skipIf(not have_root(), "requires root privileges")


### PR DESCRIPTION
Add locking to Manager operations that modify external resources: before operating on a named snapshot set, acquire a BSD-style flock() lock on /run/lock/snapm/<name>.lock, and release the lock at the end of the operation.

Initially this is a PoC/trial to evaluate the changes necessary and to test them in CI. Depending on the results of the trial this may or may not be included in a future release.

Resolves: #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Delete snapshot sets by name or UUID; explicit activate/deactivate snapshot-set actions.

- Changes
  - CLI now requires root; non-root executions exit with an error.
  - Identifier validation tightened with clearer invalid-identifier errors.

- Bug Fixes
  - Improved concurrency safety with per-snapshot-set locking across threads and processes.

- Tests
  - Test suites gated to run only as root; expanded tests covering locking, path handling and identifier validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->