### PR TITLE
Add support for snapshot set 'split' and 'prune' operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ provisioned snapshots are supported.
                 * [rename](#rename)
                 * [revert](#revert)
                 * [resize](#resize)
+                * [split](#split)
                 * [activate](#activate)
                 * [deactivate](#deactivate)
                 * [autoactivate](#autoactivate)
@@ -268,6 +269,30 @@ policy:
 
 ```
 # snapm snapset resize backup --size-policy 200%USED
+```
+
+##### split
+Split snapshots from an existing snapshot set into a new snapshot set.
+
+Split the snapshot set named 'name' into a new snapshot set named
+'new\_name'. Each listed source from 'name' is split into the new
+snapshot set. Sources that are not listed on the command line remain part of
+the original snapshot set. It is an error to split all sources from a
+snapshot set: in this case use 'snapm snapset rename' instead.
+
+To split the source "/home" from the existing snapshot set "upgrade" into a
+new snapshot set named "noupgrade":
+
+```
+# snapm snapset split upgrade noupgrade /home
+SnapsetName:      noupgrade
+Sources:          /home
+NrSnapshots:      1
+Time:             2025-03-31 20:21:29
+UUID:             30e69b86-5c48-5e5d-be1a-bf3d63aef8f7
+Status:           Inactive
+Autoactivate:     no
+Bootable:         no
 ```
 
 ##### activate

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -9,7 +9,7 @@
 ..
 .
 .de ARG_SNAPSET_COMMANDS
-.  RI [ create | delete | rename | revert | resize | activate | deactivate | autoactivate | list | show ]
+.  RI [ create | delete | rename | revert | resize | split | activate | deactivate | autoactivate | list | show ]
 ..
 .
 .de ARG_SNAPSHOT_TYPE
@@ -145,6 +145,19 @@ Snapm \(em Linux snapshot manager
 .  ad b
 ..
 .CMD_SNAPSET_RESIZE
+.
+.HP
+.B snapm
+.de CMD_SNAPSET_SPLIT
+.  ad l
+.  BR snapset
+.  BR \fBsplit
+.  IR name
+.  IR new_name
+.  IR \fIsource\fP ...
+.  ad b
+..
+.CMD_SNAPSET_SPLIT
 .
 .HP
 .B snapm
@@ -712,6 +725,18 @@ Size policies may be specified on a per-source basis using the same syntax as
 the \fBsnapset create\fP command. A default size policy can be set using the
 \fB--size-policy\fP argument. If no source paths are specified the command
 applies the default size policy to each member of the snapshot set.
+.
+.HP
+.B snapm
+.CMD_SNAPSET_SPLIT
+.br
+Split snapshots from an existing snapshot set into a new snapshot set.
+
+Split the snapshot set named \fBname\fP into a new snapshot set named
+\&'\fBnew_name\fP'. Each listed source from '\fBname\fP' is split into the new
+snapshot set. Sources that are not listed on the command line remain part of
+the original snapshot set. It is an error to split \fIall\fP sources from a
+snapshot set: in this case use '\fBsnapm snapset rename\fP' instead.
 .
 .HP
 .B snapm

--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -161,6 +161,18 @@ Snapm \(em Linux snapshot manager
 .
 .HP
 .B snapm
+.de CMD_SNAPSET_PRUNE
+.  ad l
+.  BR snapset
+.  BR \fBprune
+.  IR name
+.  IR \fIsource\fP ...
+.  ad b
+..
+.CMD_SNAPSET_PRUNE
+.
+.HP
+.B snapm
 .de CMD_SNAPSET_ACTIVATE
 .  ad l
 .  BR snapset
@@ -737,6 +749,18 @@ Split the snapshot set named \fBname\fP into a new snapshot set named
 snapshot set. Sources that are not listed on the command line remain part of
 the original snapshot set. It is an error to split \fIall\fP sources from a
 snapshot set: in this case use '\fBsnapm snapset rename\fP' instead.
+.
+.HP
+.B snapm
+.CMD_SNAPSET_PRUNE
+.br
+Prune snapshots from an existing snapshot set.
+
+Prune the listed sources from the snapshot set named \fBname\fP. The listed
+snapshot sources are pruned from the snapshot set and permanently deleted.
+Care should be taken since this operation cannot be reversed. It is an error
+to prune \fIall\fP sources from a snapshot set: in this case use
+\&'\fBsnapm snapset delete\fP' instead.
 .
 .HP
 .B snapm

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -258,6 +258,12 @@ class SnapmRecursionError(SnapmError):
     """
 
 
+class SnapmArgumentError(SnapmError):
+    """
+    An invalid argument was passed to a snapshot manager API call.
+    """
+
+
 #
 # Selection criteria class
 #
@@ -1613,6 +1619,7 @@ __all__ = [
     "SnapmPluginError",
     "SnapmStateError",
     "SnapmRecursionError",
+    "SnapmArgumentError",
     "Selection",
     "size_fmt",
     "is_size_policy",

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -557,6 +557,21 @@ def split_snapset(manager, name, new_name, sources):
     return manager.split_snapshot_set(name, new_name, sources)
 
 
+def prune_snapset(manager, name, sources):
+    """
+    Prune snapshots from an existing snapshot set.
+
+    Remove snapshots from an existing snapshot set named ``name``. The
+    snapshot sources listed in ``sources`` are pruned (deleted) from the
+    named snapshot set.
+
+    :param name: The name of the snapshot set to prune.
+    :param sources: The sources to prune from ``name``.
+    :returns: A ``SnapshotSet`` object representing the pruned snapshot set
+    """
+    return manager.split_snapshot_set(name, None, sources)
+
+
 def show_snapshots(manager, selection=None, json=False):
     """
     Show snapshots matching selection criteria.
@@ -906,6 +921,27 @@ def _split_cmd(cmd_args):
         cmd_args.name,
         snapset.name,
         ", ".join(snapset.sources),
+    )
+    print(snapset)
+    return 0
+
+
+def _prune_cmd(cmd_args):
+    """
+    Prune snapshot set command handler.
+
+    Attempt to prune the specified sources from the given snapshot set.
+
+    :param cmd_args: Command line arguments for the command.
+    :returns: integer status code returned from ``main()``
+    """
+    manager = Manager()
+
+    snapset = prune_snapset(manager, cmd_args.name, cmd_args.sources)
+    _log_info(
+        "Pruned sources (%s) from snapset '%s'",
+        snapset.name,
+        ", ".join(cmd_args.sources),
     )
     print(snapset)
     return 0
@@ -1305,6 +1341,7 @@ RENAME_CMD = "rename"
 RESIZE_CMD = "resize"
 REVERT_CMD = "revert"
 SPLIT_CMD = "split"
+PRUNE_CMD = "prune"
 ACTIVATE_CMD = "activate"
 DEACTIVATE_CMD = "deactivate"
 AUTOACTIVATE_CMD = "autoactivate"
@@ -1447,6 +1484,26 @@ def _add_snapset_subparser(type_subparser):
         type=str,
         nargs="+",
         help="A device or mount point to be split from this snapshot set",
+    )
+
+    # snapset prune command
+    snapset_prune_parser = snapset_subparser.add_parser(
+        PRUNE_CMD, help="Prune snapshots from snapshot sets"
+    )
+    snapset_prune_parser.set_defaults(func=_prune_cmd)
+    snapset_prune_parser.add_argument(
+        "name",
+        metavar="NAME",
+        type=str,
+        action="store",
+        help="The name of the snapshot set to be split",
+    )
+    snapset_prune_parser.add_argument(
+        "sources",
+        metavar="SOURCE",
+        type=str,
+        nargs="+",
+        help="A device or mount point to be pruned from this snapshot set",
     )
 
     # snapset revert command

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -605,7 +605,9 @@ def _check_snapset_status(snapset, operation):
             _log_error("Cannot operate on invalid snapshot set '%s'", snapset.name)
         if snapset.status == SnapStatus.REVERTING:
             _log_error("Cannot operate on reverting snapshot set '%s'", snapset.name)
-        raise SnapmStateError(f"Failed to {operation} snapset '{snapset.name}'")
+        raise SnapmStateError(
+            f"Failed to {operation} snapset '{snapset.name}': status is '{snapset.status}'"
+        )
 
 
 def _find_mount_point_for_devpath(devpath):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,7 @@ class MockArgs(object):
     identifier = None
     debug = None
     name = None
+    new_name = None
     name_prefixes = False
     no_headings = False
     options = ""

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -380,6 +380,21 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(len(sets), 1)
         self.assertTrue(to_split in sets[0].sources)
 
+    def test_main_snapset_prune(self):
+        self.manager.create_snapshot_set("testset0", self.mount_points())
+        to_prune = self.mount_points()[0]
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "prune"]
+        args.append("testset0")
+        args.append(to_prune)
+        command.main(args)
+
+        # Refresh manager context
+        self.manager.discover_snapshot_sets()
+
+        # Verify prune
+        pruned = self.manager.find_snapshot_sets(snapm.Selection(name="testset0"))[0]
+        self.assertFalse(to_prune in pruned.sources)
+
     def test_main_snapset_list(self):
         self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "list"]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -363,6 +363,23 @@ class CommandTests(unittest.TestCase):
             command.main(args)
         self.manager.delete_snapshot_sets(snapm.Selection(name="testset0"))
 
+    def test_main_snapset_split(self):
+        self.manager.create_snapshot_set("testset0", self.mount_points())
+        to_split = self.mount_points()[0]
+        args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "split"]
+        args.append("testset0")
+        args.append("testset1")
+        args.append(to_split)
+        command.main(args)
+
+        # Refresh manager context
+        self.manager.discover_snapshot_sets()
+
+        # Verify split
+        sets = self.manager.find_snapshot_sets(snapm.Selection(name="testset1"))
+        self.assertEqual(len(sets), 1)
+        self.assertTrue(to_split in sets[0].sources)
+
     def test_main_snapset_list(self):
         self.manager.create_snapshot_set("testset0", self.mount_points())
         args = [os.path.join(os.getcwd(), "bin/snapm"), "snapset", "list"]


### PR DESCRIPTION
Add support for splitting and pruning snapshot sets:

```
# Split sources_to_split from snapshot set old_name to snapshot set new_name:
# snapm snapset split <old_name> <new_name> <sources_to_split>
```

```
# Delete sources_to_prune from snapshot set name:
# snapm snapset prune <name> <sources_to_prune>
```

Resolves: #98 