### PR TITLE
snapm: fix Manager.split_snapshot_sets() with empty sources

### DIFF
--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -1264,6 +1264,11 @@ class Manager:
         snapset = self.by_name[name]
         _check_snapset_status(snapset, op)
 
+        if not source_specs:
+            raise SnapmArgumentError(
+                f"SnapshotSet {op} requires at least one source argument"
+            )
+
         # Parse size policies and normalise mount paths
         (sources, size_policies) = _parse_source_specs(source_specs, None)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -844,6 +844,15 @@ class ManagerTests(unittest.TestCase):
             # Split non-existent source from snapshot set
             split = self.manager.split_snapshot_set(testset, splitset, [split_source])
 
+    def test_split_snapshot_set_split_empty_sources(self):
+        testset = "testset0"
+        splitset = "testset1"
+        self.manager.create_snapshot_set(testset, self.mount_points())
+
+        with self.assertRaises(snapm.SnapmArgumentError):
+            # Split [] from snapshot set
+            split = self.manager.split_snapshot_set(testset, splitset, [])
+
     def test_split_snapshot_set_prune(self):
         testset = "testset0"
         self.manager.create_snapshot_set(testset, self.mount_points())
@@ -878,6 +887,14 @@ class ManagerTests(unittest.TestCase):
         with self.assertRaises(snapm.SnapmArgumentError):
             # Split split_source from snapshot set
             split = self.manager.split_snapshot_set(testset, None, split_sources)
+
+    def test_split_snapshot_set_prune_empty_sources(self):
+        testset = "testset0"
+        self.manager.create_snapshot_set(testset, self.mount_points())
+
+        with self.assertRaises(snapm.SnapmArgumentError):
+            # Split [] from snapshot set
+            split = self.manager.split_snapshot_set(testset, None, [])
 
     def test_split_snapshot_set_prune_size_policy_raises(self):
         testset = "testset0"


### PR DESCRIPTION
The `snapm.manager.Manger.split_snapshot_sets()` method checks whether the original snapshot set would be empty after the operation and raises an error if this is the case. There is no corresponding check to ensure that the destination snapshot set is not empty (i.e. the sources passed to the `split_snapshot_set()` method were empty).

The snapm.command wrappers already require the sources argument:

```shell
  root@localhost:~/src/git/snapm# snapm snapset split upgrade noupgrade
  usage: snapm snapset split [-h] NAME NEW_NAME SOURCE [SOURCE ...]
  snapm snapset split: error: the following arguments are required: SOURCE
```

But the API does not enforce this, leading to a snapshot set with no sources and NrSnapshots == 0:

```python
  >>> p = m.split_snapshot_set("upgrade", "noupgrade", [])
  DEBUG - Blocking termination signals {<Signals.SIGINT: 2>, <Signals.SIGTERM: 15>}
  INFO - Attempting to split snapshot set 'upgrade'
  DEBUG - Splitting snapshot  from snapshot set 'upgrade'
  INFO - Attempting rename for snapshot set 'upgrade' to 'noupgrade'
  DEBUG - Unblocking termination signals {<Signals.SIGINT: 2>, <Signals.SIGTERM: 15>}
  >>> p
  <snapm._snapm.SnapshotSet object at 0x7eff5a90d220>
  >>> print(p)
  SnapsetName:      noupgrade
  Sources:
  NrSnapshots:      0
  Time:             2025-04-01 15:02:37
  UUID:             fab385b4-5912-54f6-8458-9b487eaf7b50
  Status:           Active
  Autoactivate:     yes
  Bootable:         no
```

In practice this makes the call a no-op but it's pointless and confusing to allow this combination of arguments: raise a SnapmArgumentError if the source_specs list is empty or None.

Fixes: a32e85f
Related: #98, #174
Resolves: #179