### PR TITLE
snapm: unify filtering for valid characters in names

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -520,10 +520,17 @@ Display the version of \fBsnapm\fP and exit.
 Snapm manages named collections of snapshots taken at a common point in time as
 \fIsnapshot sets\fP. A snapshot set is created from a list of sources (mount
 point or block device paths) and allows the state of the system to be captured
-spanning over several volumes.  Valid characters for snapset names are A-Z,
-a-z, 0-9, -, ., and +. Snapshot sets and snapshots are also identified by a
-unique UUID value. The terms \fIsnapshot set\fP and \fIsnapset\fP are used
-interchangeably in this manual page.
+spanning over several volumes.
+
+Valid characters for snapset names are:
+.BR a \(en z
+.BR A \(en Z
+.BR 0 \(en 9
+.B + . -
+.P
+Snapshot sets and snapshots are also identified by a unique UUID value. The
+terms \fIsnapshot set\fP and \fIsnapset\fP are used interchangeably in this
+manual page.
 
 A plugin model is used to map mount points or devices onto possible snapshot
 \fIproviders\fP. A provider plugin must exist for each source path specified

--- a/snapm/_snapm.py
+++ b/snapm/_snapm.py
@@ -11,6 +11,7 @@ Global definitions for the top-level snapm package.
 from uuid import UUID, uuid5
 from datetime import datetime
 from enum import Enum
+import string
 import json
 import math
 import logging
@@ -96,6 +97,12 @@ SNAPSHOT_DEV_PATH = "DevicePath"
 # Constants for Snapshot and SnapshotSet property values
 SNAPSET_INDEX_NONE = -1
 SNAPSHOT_INDEX_NONE = -1
+
+
+# Constant for allow-listed name characters
+SNAPM_VALID_NAME_CHARS = set(
+    string.ascii_lowercase + string.ascii_uppercase + string.digits + "+_.-"
+)
 
 
 class SnapmLogger(logging.Logger):
@@ -1598,6 +1605,7 @@ __all__ = [
     "SNAPSHOT_DEV_PATH",
     "SNAPSET_INDEX_NONE",
     "SNAPSHOT_INDEX_NONE",
+    "SNAPM_VALID_NAME_CHARS",
     "SNAPM_DEBUG_MANAGER",
     "SNAPM_DEBUG_COMMAND",
     "SNAPM_DEBUG_REPORT",

--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -32,6 +32,7 @@ from snapm.manager.boot import (
 
 from snapm import (
     SNAPM_DEBUG_MANAGER,
+    SNAPM_VALID_NAME_CHARS,
     SnapmError,
     SnapmCalloutError,
     SnapmNoSpaceError,
@@ -881,11 +882,11 @@ class Manager:
         :raises: ``SnapmExistsError`` if the name is already in use, or
                  ``SnapmInvalidIdentifierError`` if the name fails validation.
         """
-        invalid_chars = ["/", "\\", "_", " "]
         if name in self.by_name:
             raise SnapmExistsError(f"Snapshot set named '{name}' already exists")
-        for char in invalid_chars:
-            if char in name:
+        for char in name:
+            # Underscore is specifically disallowed in snapset names.
+            if char == "_" or char not in SNAPM_VALID_NAME_CHARS:
                 raise SnapmInvalidIdentifierError(
                     f"Snapshot set name cannot include '{char}'"
                 )

--- a/snapm/manager/plugins/_plugin.py
+++ b/snapm/manager/plugins/_plugin.py
@@ -11,6 +11,8 @@ Snapshot manager plugin helpers.
 import os
 from os.path import sep as path_sep, ismount
 
+from snapm import SNAPM_VALID_NAME_CHARS
+
 _MOUNT_SEPARATOR = "-"
 _ESCAPED_MOUNT_SEPARATOR = "--"
 
@@ -33,31 +35,6 @@ DMSETUP_REPORT_SEP = ":"
 # Fields: origin_name-snapset_snapset-name_timestamp_mount-point
 SNAPSHOT_NAME_FORMAT = "%s-snapset_%s_%d_%s"
 
-_bad_chars = [
-    ":",
-    "?",
-    "@",
-    "[",
-    "]",
-    "#",
-    "<",
-    ">",
-    "{",
-    "}",
-    "~",
-    ";",
-    "%",
-    "$",
-    "£",
-    '"',
-    "!",
-    "*",
-    "&",
-    "^",
-    "`",
-    "'",
-]
-
 
 def _escape_bad_chars(path):
     """
@@ -68,7 +45,7 @@ def _escape_bad_chars(path):
     """
     escaped = ""
     for char in path:
-        if char in _bad_chars:
+        if char != path_sep and char not in SNAPM_VALID_NAME_CHARS:
             escaped = escaped + "." + char.encode("utf8").hex()
         else:
             if char == ".":

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -430,6 +430,14 @@ class ManagerTests(unittest.TestCase):
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
             self.manager.create_snapshot_set("bad name", self.mount_points())
 
+    def test_create_snapshot_set_bad_name_at(self):
+        with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
+            self.manager.create_snapshot_set("bad@name", self.mount_points())
+
+    def test_create_snapshot_set_bad_name_pipe(self):
+        with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:
+            self.manager.create_snapshot_set("bad|name", self.mount_points())
+
     def test_create_snapshot_set_name_too_long(self):
         name = "a" * 127
         with self.assertRaises(snapm.SnapmInvalidIdentifierError) as cm:


### PR DESCRIPTION
Before:

```
  root@localhost:~/src/git/snapm# snapm snapset create bad@name / /var /home
  ERROR - Error creating snapshot set member bad@name: lvcreate failed with: Logical volume name "root-snapset_bad@name_1743537024_-" is invalid.
    Run `lvcreate --help' for more information.
  ERROR - Command failed: Could not create all snapshots for set bad@name

  root@localhost:~/src/git/snapm# snapm snapset create bad\|name / /var /home
  ERROR - Error creating snapshot set member bad|name: lvcreate failed with: Logical volume name "root-snapset_bad|name_1743537258_-" is invalid.
    Run `lvcreate --help' for more information.
  ERROR - Command failed: Could not create all snapshots for set bad|name
```

After:

```
  root@localhost:~/src/git/snapm# snapm snapset create bad@name / /var /home
  ERROR - Command failed: Snapshot set name cannot include '@'

  root@localhost:~/src/git/snapm# snapm snapset create bad\|name / /var /home
  ERROR - Command failed: Snapshot set name cannot include '|'
```

Resolves: #181