### PR TITLE
dist: avoid Python packaging warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "snapm"
 version = "0.4.0"
-license = { text="GPL-2.0-only AND Apache-2.0" }
 authors = [
   { name="Bryn M. Reeves", email="bmr@redhat.com" },
 ]
 description = "Snapshot Manager"
 readme = "README.md"
 requires-python = ">=3.9"
+dynamic = ["license"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
```
  ********************************************************************************
  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

  By 2026-Feb-18, you need to update your project and remove deprecated calls
  or your builds will no longer be supported.

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************
```
~~We can't use a simple string since that breaks downstream builds on distributions that do not yet support PEP639. For now switch to using license-files in pyproject.toml and setup.cfg.~~

See also snapshotmanager/snapm#42

Referring to the discussion in pypa/packaging-problems#870 it's not recommended to set the 'license' or 'license-files' keys in the '[project]' table of pyproject.toml due to these problems.

Removing these keys from pyproject.toml, leaving the 'license' key in setup.cfg and adding 'dynamic = ["license"]' to '[project]' seem to do the right thing for the current GH build targets.

Resolves: #184