### PR TITLE
dist: fix spec file issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ Issues = "https://github.com/snapshotmanager/snapm/issues"
 [build-system]
 requires = [
     "wheel",
+    "pytest",
     "setuptools>=61.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/snapm.spec
+++ b/snapm.spec
@@ -98,7 +98,7 @@ rm doc/Makefile
 rm doc/conf.py
 
 %check
-pytest-3 --log-level=debug -v
+%pytest --log-level=debug -v
 
 %files
 # Main license for snapm (Apache-2.0)

--- a/snapm.spec
+++ b/snapm.spec
@@ -13,6 +13,7 @@ Source0:	%{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildArch:	noarch
 
 BuildRequires:	make
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-devel
 BuildRequires:	python3-pip
@@ -85,18 +86,10 @@ rm -rf doc/_build
 rm -f doc/*.rst
 %endif
 
-%if 0%{?centos} || 0%{?rhel}
-%py3_build
-%else
 %pyproject_wheel
-%endif
 
 %install
-%if 0%{?centos} || 0%{?rhel}
-%py3_install
-%else
 %pyproject_install
-%endif
 
 mkdir -p ${RPM_BUILD_ROOT}/%{_mandir}/man8
 install -m 644 man/man8/snapm.8 ${RPM_BUILD_ROOT}/%{_mandir}/man8
@@ -119,11 +112,7 @@ pytest-3 --log-level=debug -v
 %license LICENSE
 %doc README.md
 %{python3_sitelib}/%{name}/
-%if 0%{?centos} || 0%{?rhel}
-%{python3_sitelib}/%{name}-*.egg-info/
-%else
 %{python3_sitelib}/%{name}*.dist-info/
-%endif
 
 %if 0%{?sphinx_docs}
 %files -n python3-snapm-doc


### PR DESCRIPTION
Suggested improvements to the `snapm.spec` file from the [Fedora Review Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2357266):

* Drop centos/rhel special casing and build everything with `%pyproject_wheel`/`%pyproject_install`
* Use `%pytest -- --log-level=debug` instead of directly calling `pytest-3`
* Switch to [dynamic BuildRequires](https://fedoraproject.org/wiki/Changes/DynamicBuildRequires)
