### PR TITLE
dist: pass test suite directory as positional arg to pytest macro

### DIFF
--- a/snapm.spec
+++ b/snapm.spec
@@ -98,7 +98,7 @@ rm doc/Makefile
 rm doc/conf.py
 
 %check
-%pytest --log-level=debug -v
+%pytest --log-level=debug -v tests/
 
 %files
 # Main license for snapm (Apache-2.0)


### PR DESCRIPTION
To be more inline with [Fedora Python Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/):

```
  %pytest --log-level=debug -v tests/
```

Rather than:

```
  %pytest --log-level=debug -v
```

Resolves: #216