### PR TITLE
boot: tolerate missing boom.command.create_config()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pycodestyle>=2.4.0
 coverage>=4.0.3
 Sphinx>=1.3.5
-boom-boot>=1.6.4
+boom-boot>=1.6.0
 dbus-client-gen>=0.4
 dbus-python-client-gen>=0.7
 justbytes>=0.14


### PR DESCRIPTION
Support a wider range of boom versions back to 1.6.0 by handling the absence of `boom.command.create_config()`, logging the reason for the failure and raising an appropriate SnapmCalloutError if no usable boom configuration could either be found or created.

Resolves: #221