### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ Issues = "https://github.com/snapshotmanager/snapm/issues"
 
 [build-system]
 requires = [
-    "wheel",
     "pytest",
     "setuptools>=53",
 ]


### PR DESCRIPTION
 - current version of setuptools (70.1+) does not need wheel at all
 - older versions of setuptools would fetch wheel when building wheels (but not sdists)