### PR TITLE
snapm: fix swapped _log_info() args in 'snapm snapset prune' output

### DIFF
--- a/snapm/command.py
+++ b/snapm/command.py
@@ -1221,8 +1221,8 @@ def _prune_cmd(cmd_args):
     snapset = prune_snapset(manager, cmd_args.name, cmd_args.sources)
     _log_info(
         "Pruned sources (%s) from snapset '%s'",
-        snapset.name,
         ", ".join(cmd_args.sources),
+        snapset.name,
     )
     print(snapset)
     return 0


### PR DESCRIPTION
Resolves: #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected log formatting in the prune operation: messages now list the pruned sources followed by the snapset name for accurate, readable logs.
  * Improves clarity for troubleshooting and audit trails; no changes to behavior, results, or subsequent printed output.
  * No modifications to public interfaces or command usage; only log text ordering is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->