### PR TITLE
snapm: fix report field definition for snapshot_origin

### DIFF
--- a/snapm/command.py
+++ b/snapm/command.py
@@ -289,8 +289,8 @@ _snapshot_fields = [
     FieldType(
         PR_SNAPSHOT,
         "origin",
-        "Origin",
         SNAPSHOT_ORIGIN,
+        "Snapshot origin",
         16,
         REP_STR,
         lambda f, d: f.report_str(d.origin),


### PR DESCRIPTION
SNAPSHOT_UUID was used as the field description: it should be the header, and the description should be "Snapshot origin".

Resolves: #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the label in snapshot reports from “Origin” to “Snapshot origin” for clearer context in PR snapshot displays.
  - Improves readability and reduces ambiguity when interpreting where a snapshot comes from.
  - Visual-only change; no impact on functionality or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->