### PR TITLE
snapm: make --yes/--no required and mutually exclusive for autoactivate

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -241,7 +241,7 @@ snapm \- Linux Snapshot Manager
 .de CMD_SNAPSET_AUTOACTIVATE
 .  B snapset
 .  B autoactivate
-.  RB [ --yes | --no ] " "\c
+.  RB --yes | --no " "\c
 .  ARG_NAME_OR_UUID
 ..
 .CMD_SNAPSET_AUTOACTIVATE
@@ -293,7 +293,7 @@ snapm \- Linux Snapshot Manager
 .de CMD_SNAPSHOT_AUTOACTIVATE
 .  B snapshot
 .  B autoactivate
-.  RB [ --yes | --no ] " "\c
+.  RB --yes | --no " "\c
 .  ARG_NAME_OR_UUID
 .  ARG_SNAPSHOT_NAME_OR_UUID
 ..

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -1274,7 +1274,7 @@ def _autoactivate_cmd(cmd_args):
     """
     manager = Manager()
     select = Selection.from_cmd_args(cmd_args)
-    auto = bool(cmd_args.yes)
+    auto = cmd_args.autoactivate
     count = manager.set_autoactivate(select, auto=auto)
     _log_info("Set autoactivate=%s for %d snapshot sets", bool_to_yes_no(auto), count)
     return 0
@@ -1379,11 +1379,11 @@ def _snapshot_autoactivate_cmd(cmd_args):
         _log_error("Could not find snapshots matching %s", select)
         return 1
     count = 0
-    auto = bool(cmd_args.yes)
+    auto = cmd_args.autoactivate
     for snapshot in snapshots:
         snapshot.autoactivate = auto
         count += 1
-    _log_info("Set autoactivation status for %d snapshots", count)
+    _log_info("Set autoactivate=%s for %d snapshots", bool_to_yes_no(auto), count)
     return 0
 
 
@@ -1745,15 +1745,18 @@ def _add_report_args(parser):
 
 
 def _add_autoactivate_args(parser):
-    parser.add_argument(
+    yes_no_mutex_group = parser.add_mutually_exclusive_group(required=True)
+    yes_no_mutex_group.add_argument(
         "--yes",
+        dest="autoactivate",
         action="store_true",
-        help="Enable snapshot autoactivation",
+        help="Enable autoactivation",
     )
-    parser.add_argument(
+    yes_no_mutex_group.add_argument(
         "--no",
-        action="store_true",
-        help="Disable snapshot autoactivation",
+        action="store_false",
+        dest="autoactivate",
+        help="Disable autoactivation",
     )
 
 


### PR DESCRIPTION
Resolves: #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Autoactivation now requires an explicit choice: either --yes or --no. The options are mutually exclusive and one must be provided; omitting both returns an error to avoid ambiguity.

- Documentation
  - Manual pages updated to show the required, unbracketed --yes | --no syntax and clarify that --yes enables autoactivation and --no disables it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->