### PR TITLE
snapm: require -p/--policy-type for 'snapm schedule create'

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -337,14 +337,14 @@ snapm \- Linux Snapshot Manager
 .de CMD_SCHEDULE_CREATE
 .  B schedule
 .  B create
+.  BR  -p | --policy-type\ \c
+.  IR policy_type " "\c
 .  RB [ -b | --bootable] " "\c
 .  RB [ -C | --calendarspec\ \c
 .  IR calendarspec] " "\c
 .  RB [ -r | --revert] " "\c
 .  RB [ -s | --size-policy\ \c
 .  IR policy] " "\c
-.  RB [ -p | --policy-type\ \c
-.  IR policy_type] " "\c
 .  RB [ --keep-count\ \c
 .  IR count ] " "\c
 .  RB [ --keep-years\ \c

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -1773,7 +1773,9 @@ def _add_policy_args(parser):
     parser.add_argument(
         "-p",
         "--policy-type",
-        type=str,
+        type=lambda s: s.lower(),
+        required=True,
+        choices=["all", "count", "age", "timeline"],
         help="Garbage collection policy type",
     )
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -234,6 +234,18 @@ class CommandTestsSimple(CommandTestsBase):
         with self.assertRaises(SystemExit) as cm:
             command.main(args)
 
+    def test_main_schedule_create_requires_policy_type(self):
+        args = self.get_debug_main_args()
+        args += [
+            "schedule", "create",
+            "--keep-days", "7",
+            "--calendarspec", "hourly",
+            "hourly", "/", "/var",
+        ]
+        with self.assertRaises(SystemExit) as cm:
+            command.main(args)
+        self.assertEqual(cm.exception.code, 2)
+
 
 @unittest.skipIf(not have_root(), "requires root privileges")
 class CommandTests(CommandTestsBase):
@@ -814,6 +826,25 @@ class CommandTests(CommandTestsBase):
         args += ["snapset", "revert"]
         self.assertEqual(command.main(args), 1)
 
+    def test_main_schedule_create_delete_uppercase_variants(self):
+        for p in ["ALL", "COUNT", "AGE", "TIMELINE"]:
+            name = f"hourly-{p.lower()}"
+            with self.subTest(policy=p):
+                args = self.get_debug_main_args()
+                args += ["schedule", "create", "--policy-type", p, "--calendarspec", "hourly", name]
+                if p == "COUNT":
+                    args.extend(["--keep-count", "1"])
+                elif p == "AGE":
+                    args.extend(["--keep-days", "1"])
+                elif p == "TIMELINE":
+                    args.extend(["--keep-daily", "1"])
+                args.extend(self.mount_points())
+                self.assertEqual(command.main(args), 0)
+
+                args = self.get_debug_main_args()
+                args += ["schedule", "delete", name]
+                self.assertEqual(command.main(args), 0)
+
     def test_main_schedule_create_show_list_gc_delete_ALL(self):
         args = self.get_debug_main_args()
         args += [
@@ -824,8 +855,8 @@ class CommandTests(CommandTestsBase):
             "--calendarspec",
             "hourly",
             "hourly",
-            " ".join(self.mount_points())
         ]
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()
@@ -860,8 +891,8 @@ class CommandTests(CommandTestsBase):
             "--calendarspec",
             "hourly",
             "hourly",
-            " ".join(self.mount_points())
         ]
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()
@@ -896,8 +927,8 @@ class CommandTests(CommandTestsBase):
             "--calendarspec",
             "hourly",
             "hourly",
-            " ".join(self.mount_points())
         ]
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()
@@ -936,8 +967,8 @@ class CommandTests(CommandTestsBase):
             "--calendarspec",
             "hourly",
             "hourly",
-            " ".join(self.mount_points())
         ]
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()
@@ -972,8 +1003,8 @@ class CommandTests(CommandTestsBase):
             "--calendarspec",
             "hourly",
             "hourly",
-            " ".join(self.mount_points())
         ]
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()
@@ -1001,7 +1032,7 @@ class CommandTests(CommandTestsBase):
             "hourly",
             "hourly",
         ]
-        args += self.mount_points()
+        args.extend(self.mount_points())
         self.assertEqual(command.main(args), 0)
 
         args = self.get_debug_main_args()


### PR DESCRIPTION
```
# snapm schedule create --keep-days 7 -C hourly hourly / /var
usage: snapm schedule create [-h] [-C CALENDARSPEC] [-s SIZE_POLICY] [-b] [-r] -p {all,count,age,timeline} [--keep-count COUNT] [--keep-years YEARS] [--keep-months MONTHS]
                             [--keep-weeks WEEKS] [--keep-days DAYS] [--keep-yearly COUNT] [--keep-quarterly COUNT] [--keep-monthly COUNT] [--keep-weekly COUNT] [--keep-daily COUNT]
                             [--keep-hourly COUNT] [-j]
                             SCHEDULE_NAME SOURCE [SOURCE ...]
snapm schedule create: error: the following arguments are required: -p/--policy-type
```
Resolves: #458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - CLI policy-type option is now required, validated at parse time, restricted to: all, count, age, timeline, and accepted case-insensitively.

- Documentation
  - Man page formatting updated for clearer display of the policy-type option.

- Tests
  - New and updated tests cover required policy-type behavior, uppercase variants, and schedule-related command flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->