### PR TITLE
lvm2: fix confusing error message when probing non-dm devices

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -479,7 +479,7 @@ class ManagerTests(unittest.TestCase):
             self.manager.create_snapshot_set("testset0", [non_mount])
 
     def test_create_snapshot_set_no_provider(self):
-        with self.assertRaises(snapm.SnapmError) as cm:
+        with self.assertRaises(snapm.SnapmNoProviderError):
             self.manager.create_snapshot_set("testset0", ["/boot"])
 
     def test_rename_snapshot_set(self):


### PR DESCRIPTION
Currently:

```text
root@f42-snapm-vm1:/var/tmp/snapm# snapm snapset create plugtest /boot /
ERROR - Command failed: Error calling dmsetup: Device vda2 not found
Command failed.
```

Should be:

```text
root@f42-snapm-vm1:/var/tmp/snapm# snapm snapset create plugtest /boot /
ERROR - Command failed: Could not find snapshot provider for /boot
```

Resolves: #475
Resolves: #476  
Resolves: #477 
Resolves: #480 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and caching of device-mapper and LVM presence to avoid false positives/negatives.
  * Explicit error when device-mapper is missing.
  * More accurate identification of LVM-backed devices using major-number checks for safer snapshot operations.

* **Tests**
  * Updated no-provider test to expect a more specific error when creating a snapshot set without a supported provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->