### PR TITLE
schedule: write_config(): do not reference tmp_path when it is undefined

### DIFF
--- a/snapm/manager/_schedule.py
+++ b/snapm/manager/_schedule.py
@@ -895,7 +895,7 @@ class Schedule:
                 ) from err
         except OSError as err:  # pragma: no cover
             raise SnapmSystemError(
-                f"Filesystem error writing schedule temporary file '{tmp_path}': {err}"
+                f"Filesystem error writing schedule temporary file for '{sched_path}': {err}"
             ) from err
         self._sched_path = sched_path
 


### PR DESCRIPTION
The `tmp_path` variable is assigned inside the outer try block: if the call to `tempfile.mkstemp()` call fails it will be unbound, leading to:

```
  Traceback (most recent call last):
    File "/home/jenkins/workspace/snapm-pr/arch/x86_64/distro/f_rawhide/type/snapm/tests/test_scheduler.py", line 125, in test_schedule_create_COUNT
      schedule = self.manager.scheduler.create(
          "weekly",
      ...<6 lines>...
          False,
      )
    File "/home/jenkins/workspace/snapm-pr/arch/x86_64/distro/f_rawhide/type/snapm/snapm/manager/_signals.py", line 46, in wrapper
      ret = func(*args, **kwargs)
    File "/home/jenkins/workspace/snapm-pr/arch/x86_64/distro/f_rawhide/type/snapm/snapm/manager/_manager.py", line 477, in create
      schedule.write_config(self._schedpath)
      ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
    File "/home/jenkins/workspace/snapm-pr/arch/x86_64/distro/f_rawhide/type/snapm/snapm/manager/_schedule.py", line 898, in write_config
      f"Filesystem error writing schedule temporary file '{tmp_path}': {err}"
                                                           ^^^^^^^^
  UnboundLocalError: cannot access local variable 'tmp_path' where it is not associated with a value
```

Instead report the failure to create a temporary file for the final `sched_path`, which always has a defined value.

Resolves: #378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when saving a schedule fails. The message now correctly references the intended schedule path rather than a temporary file, making it clearer which file operation failed. This enhances troubleshooting without altering behaviour or recovery flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->