### PR TITLE
snapm: reject duplicates in Scheduler.create() sources argument

### DIFF
--- a/snapm/manager/_manager.py
+++ b/snapm/manager/_manager.py
@@ -608,6 +608,8 @@ class Scheduler:
         :returns: The new ``Schedule`` instance.
         :rtype: ``Schedule``
         """
+        _, _ = _parse_source_specs(sources, default_size_policy)
+
         schedule = Schedule(
             name,
             sources,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -183,6 +183,20 @@ class SchedulerTests(unittest.TestCase):
 
         self.manager.scheduler.delete("weekly")
 
+    def test_schedule_create_duplicate_sources_raises(self):
+        self.manager = manager.Manager()
+        with self.assertRaises(snapm.SnapmInvalidIdentifierError):
+            self.manager.scheduler.create(
+                "weekly",
+                [self.mount_points()[0], self.mount_points()[0]],
+                "10%SIZE",
+                True,
+                "weekly",
+                manager.GcPolicy("weekly", manager.GcPolicyType.ALL, {}),
+                False,
+                False,
+            )
+
     def test_schedule_delete(self):
         mount_points = self.mount_points()
         sched_file = join(_ETC_SNAPM_SCHEDULE_D, "hourly.json")


### PR DESCRIPTION
Resolves: #516