### PR TITLE
boot: handle swap entries in `/etc/fstab`

### DIFF
--- a/snapm/manager/_boot.py
+++ b/snapm/manager/_boot.py
@@ -388,7 +388,6 @@ def _create_boom_boot_entry(
                     used to associate the entry with a snapshot set name or
                     UUID.
     :param root_device: The root device for the entry. Passed to root=...
-    :param lvm_root_lv: An optional LVM2 root logical volume.
     :param mounts: An optional list of mount specifications to use for the
                    boot entry. If defined fstab=no will be appended to the
                    generated kernel command line.


### PR DESCRIPTION
Handle swap entries in /etc/fstab explicitly, rather than punting them to `boom.command.create_entry(mounts=...)` to DTRT.

Resolves: #532
Resolves: #533
Resolves: #534
Resolves: #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boot entries now include detected swap specifications from system configuration so swap is preserved across boot setups.
  * Creation of boot entries accepts an optional list of swap specifications to ensure swap is recorded when entries are created.

* **Bug Fixes**
  * Swap entries are no longer treated as mounts.
  * Malformed configuration lines are ignored to prevent incorrect boot entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->