### PR TITLE
snapm: fix renaming of snapshot sets with boot entries

### DIFF
--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -307,3 +307,27 @@ class BootTestsWithRoot(BootTestsBase):
 
         # Clean up boot entry
         self.manager.delete_snapshot_sets(snapm.Selection(name="bootset0"))
+
+    def test_create_boot_entries_and_rename(self):
+        sset = self.manager.find_snapshot_sets(snapm.Selection(name="bootset0"))[0]
+        self.manager.create_snapshot_set_boot_entry(name="bootset0")
+        self.manager.create_snapshot_set_revert_entry(name="bootset0")
+
+        self.assertIsNotNone(sset.boot_entry)
+        self.assertIsNotNone(sset.revert_entry)
+
+        # Stash original boot_id values
+        orig_boot_id = sset.boot_entry.boot_id
+        orig_revert_id = sset.revert_entry.boot_id
+
+        self.manager.rename_snapshot_set("bootset0", "bootset1")
+
+        self.assertIsNotNone(sset.boot_entry)
+        self.assertIsNotNone(sset.revert_entry)
+
+        # Verify boot_id values are changed
+        self.assertNotEqual(orig_boot_id, sset.boot_entry.boot_id)
+        self.assertNotEqual(orig_revert_id, sset.revert_entry.boot_id)
+
+        # Clean up boot entries
+        self.manager.delete_snapshot_sets(snapm.Selection(name="bootset1"))


### PR DESCRIPTION
Resolves: #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot set renames now correctly handle associated boot and revert entries: entries are removed and recreated as needed, caches and public lookups are refreshed, and stability is preserved if errors occur by restoring entries or rolling back the rename; errors are logged.

* **Tests**
  * New test verifies creation of boot/revert entries and their correct update when a snapshot set is renamed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->