### PR TITLE
fsdiff: catch EOFError on truncated cache file

### DIFF
--- a/snapm/fsdiff/cache.py
+++ b/snapm/fsdiff/cache.py
@@ -245,8 +245,14 @@ def load_cache(
                     # directory is root-owned and has restrictive permissions that
                     # are verified on startup.
                     candidate = pickle.load(fp)
-            except (OSError, lzma.LZMAError, pickle.UnpicklingError) as err:
-                _log_warn("Ignoring unreadable cache file %s: %s", file_name, err)
+            except (OSError, EOFError, lzma.LZMAError, pickle.UnpicklingError) as err:
+                _log_warn("Deleting unreadable cache file %s: %s", file_name, err)
+                try:
+                    os.unlink(cache_path)
+                except OSError as err2:
+                    _log_error(
+                        "Error unlinking unreadable cache file %s: %s", file_name, err2
+                    )
                 continue
 
             _log_debug(


### PR DESCRIPTION
Resolves: #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted or truncated cache files — unreadable cache files are now removed and the app continues; if removal fails an error is logged. This reduces repeated errors and improves stability and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->