### PR TITLE
fsdiff: move detector may mis-detect identical files as moves

### DIFF
--- a/snapm/fsdiff/engine.py
+++ b/snapm/fsdiff/engine.py
@@ -1120,6 +1120,9 @@ class DiffEngine:
                 if not (entry_a.is_file and entry_a.content_hash):
                     continue
 
+                if path in tree_b and entry_a.content_hash == tree_b[path].content_hash:
+                    continue
+
                 candidates = dest_hashes.get(entry_a.content_hash)
                 if not candidates:
                     continue


### PR DESCRIPTION
Resolves: #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of file move detection by reducing false positives. Files with identical content at the same location are now handled more correctly during change tracking operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->