### PR TITLE
fsdiff: ctrl char glitches when diff -o tree --color=always | less -R

### DIFF
--- a/snapm/fsdiff/tree.py
+++ b/snapm/fsdiff/tree.py
@@ -160,7 +160,7 @@ class DiffTree:
         else:
             color, marker = self.marker_map.get(record.diff_type, ("", ""))
 
-        return f"{color}{marker}{self.term_control.NORMAL}"
+        return f"{color}{marker}{self.term_control.WHITE}"
 
     # pylint: disable=too-many-locals,too-many-branches
     def render(


### PR DESCRIPTION
Use the same workaround we already do in `-o diff` output: revert explicitly back to WHITE since `less -R` does not support the ANSI reset control sequence.

Resolves: #856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the visual colour formatting for change markers to ensure consistent and improved readability in the terminal output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->