### PR TITLE
fsdiff: tolerate missing `python-file-magic` and work around `Magic.close()` bug

### DIFF
--- a/snapm/fsdiff/filetypes.py
+++ b/snapm/fsdiff/filetypes.py
@@ -14,9 +14,14 @@ from pathlib import Path
 from enum import Enum
 import logging
 
-import magic
+try:
+    import magic
 
-from snapm import SNAPM_SUBSYSTEM_FSDIFF
+    _HAVE_MAGIC = True
+except ModuleNotFoundError:
+    _HAVE_MAGIC = False
+
+from snapm import SNAPM_SUBSYSTEM_FSDIFF, SnapmNotFoundError
 
 _log = logging.getLogger(__name__)
 
@@ -859,6 +864,9 @@ class FileTypeDetector:
         :rtype: ``FileTypeInfo``
         """
         if use_magic:
+            if not _HAVE_MAGIC:
+                raise SnapmNotFoundError("python-file-magic is not installed")
+
             # c9s magic does not have magic.error
             if hasattr(magic, "error"):
                 magic_errors = (magic.error, OSError, ValueError)


### PR DESCRIPTION
Since `magic` is not intended to be a hard dependency (it's not included in `requirements.txt`), make the imports in `snapm.fsdiff` tolerate a missing `magic` module. Check module availability in `snapm.fsdiff.fsdiffer` so that we can let the user know before doing anything expensive.

In addition, as a temporary workaround for  [rhbz#2419719 - TypeError: 'NoneType' object is not callable in magic.close()](https://bugzilla.redhat.com/show_bug.cgi?id=2419719) - monkeypatch the `magic` module to avoid this unpleasant output on process exit:

```
root@f42-snapm-vm1:~/src/git/snapm# snapm snapset diff before-upgrade . -M never -s /etc -x "*etc/lvm*" --file-types
Gathering paths from before-upgrade /etc: found 9604 paths                                     
Scanned 2919 paths in 0:00:03.048311 (excluded 6685)                                                                                                                                          
Gathering paths from System Root /etc: found 12384 paths                                       
Scanned 2923 paths in 0:00:02.603263 (excluded 9461)                                           
Found 23 differences in 0:00:00.021054                                                         
Found 2 moves in 0:00:00.006530                                                                
Built tree with 23 nodes              
/                               
└── [*] etc             
    ├── [*] dpkg         
    │   └── [<] dpkg.cfg -> /etc/opt/dpkg.cfg
    ├── [*] fstab                 
    ├── [*] ld.so.cache                      
    ├── [<] moved.conf -> /etc/movedto.conf
    ├── [>] movedto.conf <- /etc/moved.conf                                                    
    ├── [+] newfile.conf                                                                       
    ├── [*] opt                            
    │   └── [>] dpkg.cfg <- /etc/dpkg/dpkg.cfg
    ├── [+] quux                           
    │   └── [+] foo.conf                      
    ├── snapm                                                                                  
    │   ├── [*] plugins.d                                                                      
    │   │   ├── [*] lvm2-cow.conf 
    │   │   ├── [*] lvm2-thin.conf                                                             
    │   │   └── [*] stratis.conf                                                               
    │   └── [*] schedule.d                  
    │       └── [*] system-daily.json                                                                                                                                                         
    ├── [!] system-release                                                                     
    ├── systemd                                                                                
    │   └── [*] system                                                                         
    │       └── [*] timers.target.wants                                                        
    └── [*] yum.repos.d               
        └── [+] _copr:copr.fedorainfracloud.org:packit:snapshotmanager-snapm-843.repo          
Exception ignored in: <function MagicDetect.__del__ at 0x7f5b43bb3600>
Traceback (most recent call last):                                                             
  File "/usr/lib/python3.13/site-packages/magic.py", line 308, in __del__                                                                                                                     
  File "/usr/lib/python3.13/site-packages/magic.py", line 135, in close                                                                                                                       
TypeError: 'NoneType' object is not callable
```

Even if this has side effects like leaving magic resources around (it shouldn't, and if it does, that's a `python-file-magic` bug), we don't really care since our processes are short lived and this error pops up during final garbage collection on exit anyway.

Resolves: #858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of optional python-magic dependency with clearer error messages when file type detection features are used without the required package installed.

* **Improvements**
  * Enhanced robustness when optional dependencies are unavailable, preventing silent fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->