### PR TITLE
fsdiff: support DiffOptions.from_path as list

### DIFF
--- a/man/man8/snapm.8
+++ b/man/man8/snapm.8
@@ -774,7 +774,8 @@ Specify which fields to sort by.
 .
 .TP 8
 \fB-s | --start-path\fP \fIpath\fP
-(Diff) Start traversal from the specified path.
+(Diff) Start traversal from the specified path. This option may be specified
+multiple times to traverse different subtrees in a single diff operation.
 .
 .TP 8
 .B --stat

--- a/scripts/difftest.py
+++ b/scripts/difftest.py
@@ -50,8 +50,10 @@ def main():
         "-s",
         "--start-path",
         type=str,
+        action="append",
         metavar="PATH",
         dest="from_path",
+        default=None,
         help="Start traversal from PATH",
     )
     parser.add_argument(

--- a/snapm/command.py
+++ b/snapm/command.py
@@ -2778,9 +2778,14 @@ def _add_diff_args(parser):
         "-s",
         "--start-path",
         type=str,
+        action="append",
         metavar="PATH",
         dest="from_path",
-        help="Start traversal from PATH",
+        default=None,
+        help=(
+            "Start traversal from PATH: specify multiple times "
+            "to include different subtrees."
+        ),
     )
     parser.add_argument(
         "-q",

--- a/snapm/fsdiff/options.py
+++ b/snapm/fsdiff/options.py
@@ -54,8 +54,8 @@ class DiffOptions:
     file_patterns: Tuple[str, ...] = field(default_factory=tuple)
     #: File patterns to exclude (glob notation)
     exclude_patterns: Tuple[str, ...] = field(default_factory=tuple)
-    #: Start path for file system comparison
-    from_path: Optional[str] = None
+    #: Start path(s) for file system comparison
+    from_path: Optional[Union[str, Tuple[str]]] = ("/",)
     #: Do not output progress or status updates
     quiet: bool = False
 


### PR DESCRIPTION
Allow multiple `from_path` fsdiff options: this enables things like:

```
  # snapm snapset diff before-upgrade . -s /etc -s /usr
```
Avoids the need for multiple runs to look at different subtrees and makes better use of the cache:

```
  root@f42-snapm-vm1:~/src/git/snapm# snapm -d all snapset diff before-upgrade . -M never -s /etc -s /root/claude -x "*etc/lvm*"
  Gathering paths from before-upgrade /etc, /root/claude: found 51843 paths
  Scanned 25122 paths in 0:00:08.955364 (excluded 26721)
  Gathering paths from System Root /etc, /root/claude: found 64364 paths
  Scanned 25131 paths in 0:00:09.194440 (excluded 39233)
  Found 26 differences in 0:00:00.021615
  Found 2 moves in 0:00:00.008002
  Built tree with 26 nodes
  /
  ├── [*] etc
  │   ├── [*] dpkg
  │   │   ├── [<] dpkg.cfg -> /etc/dpkg/dpkg.cfg.orig
  │   │   └── [>] dpkg.cfg.orig <- /etc/dpkg/dpkg.cfg
  │   ├── [*] fstab
  │   ├── [*] ld.so.cache
  │   ├── [<] moved.conf -> /etc/movedto.conf
  │   ├── [>] movedto.conf <- /etc/moved.conf
  │   ├── [+] newfile.conf
  │   ├── [*] opt
  │   │   └── [+] dpkg.cfg
  │   ├── [+] quux
  │   │   └── [+] foo.conf
  │   ├── snapm
  │   │   ├── [*] plugins.d
  │   │   │   ├── [*] lvm2-cow.conf
  │   │   │   ├── [*] lvm2-thin.conf
  │   │   │   └── [*] stratis.conf
  │   │   └── [*] schedule.d
  │   │       └── [*] system-daily.json
  │   ├── [!] system-release
  │   ├── systemd
  │   │   └── [*] system
  │   │       └── [*] timers.target.wants
  │   └── [*] yum.repos.d
  │       └── [+] _copr:copr.fedorainfracloud.org:packit:snapshotmanager-snapm-843.repo
  └── root
      └── [*] claude
          └── [+] something_new.py
```

Resolves: #844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The start-path option now supports specifying the option multiple times to traverse multiple subtrees in a single diff.
  * Progress reporting and path displays now reflect multiple start paths.
  * Command-line parsing and configuration accept and preserve multiple start-path values while retaining single-path behaviour when only one is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->