### PR TITLE
plugins: bump plugin versions for prio support

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -1083,9 +1083,9 @@ the configured priority values:
 
    snapm plugin list
    PluginName PluginVersion PluginType       Priority
-   lvm2-cow   0.1.0         Lvm2CowSnapshot        10
-   lvm2-thin  0.1.0         Lvm2ThinSnapshot       15
-   stratis    0.1.0         StratisSnapshot        20
+   lvm2-cow   0.2.0         Lvm2CowSnapshot        10
+   lvm2-thin  0.2.0         Lvm2ThinSnapshot       15
+   stratis    0.2.0         StratisSnapshot        20
 
 Overriding Plugin Priority
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1111,9 +1111,9 @@ configuration files, verify the changes:
 
    snapm plugin list
    PluginName PluginVersion PluginType       Priority
-   lvm2-cow   0.1.0         Lvm2CowSnapshot        18
-   lvm2-thin  0.1.0         Lvm2ThinSnapshot       15
-   stratis    0.1.0         StratisSnapshot        20
+   lvm2-cow   0.2.0         Lvm2CowSnapshot        18
+   lvm2-thin  0.2.0         Lvm2ThinSnapshot       15
+   stratis    0.2.0         StratisSnapshot        20
 
 Plugin priority values must be positive integers. Setting a priority to 0 or
 a negative value will generate a warning message and cause the plugin to use

--- a/snapm/manager/plugins/_plugin.py
+++ b/snapm/manager/plugins/_plugin.py
@@ -115,7 +115,7 @@ class Plugin(ABC):
     """
 
     name = "plugin"
-    version = "0.1.0"
+    version = "0.2.0"
     snapshot_class = Snapshot
 
     def __init__(self, logger, plugin_cfg):

--- a/snapm/manager/plugins/lvm2.py
+++ b/snapm/manager/plugins/lvm2.py
@@ -1059,7 +1059,7 @@ class Lvm2Cow(_Lvm2):
     """
 
     name = "lvm2-cow"
-    version = "0.1.0"
+    version = "0.2.0"
     snapshot_class = Lvm2CowSnapshot
 
     max_name_len = LVM_MAX_NAME_LEN - LVM_COW_SNAPSHOT_NAME_LEN
@@ -1373,7 +1373,7 @@ class Lvm2Thin(_Lvm2):
     """
 
     name = "lvm2-thin"
-    version = "0.1.0"
+    version = "0.2.0"
     snapshot_class = Lvm2ThinSnapshot
 
     max_name_len = LVM_MAX_NAME_LEN

--- a/snapm/manager/plugins/stratis.py
+++ b/snapm/manager/plugins/stratis.py
@@ -436,7 +436,7 @@ class Stratis(Plugin):
     """
 
     name = "stratis"
-    version = "0.1.0"
+    version = "0.2.0"
     snapshot_class = StratisSnapshot
 
     def __init__(self, logger, plugin_cfg):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,7 +46,7 @@ class PluginTests(unittest.TestCase):
         cfg.plugin_conf_file = "concrete-test.conf"
         p = MockPlugin(log, cfg)
         info = p.info()
-        self.assertEqual(info, {"name": "plugin", "version": "0.1.0"})
+        self.assertEqual(info, {"name": "plugin", "version": "0.2.0"})
         self.assertEqual(p.priority, plugins.PLUGIN_NO_PRIORITY)
 
     def test_instantiate_base_raises(self):


### PR DESCRIPTION
Bump everything up to 0.2.0 to reflect support for plugin priorities.

Resolved: #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin suite version to 0.2.0 across all components.

* **Documentation**
  * Updated user guide to reflect version 0.2.0 in plugin examples and references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->