### PR TITLE
boot: hex escape literal ':' in values passed to systemd.{mount,swap}-extra

### DIFF
--- a/snapm/manager/_boot.py
+++ b/snapm/manager/_boot.py
@@ -166,6 +166,17 @@ class Fstab:
         return f"Fstab(path='{self.path}')"
 
 
+def _escape(orig: str) -> str:
+    """
+    Convert literal ':' characters into the hexadecimal escape (\x3a): systemd
+    will decode these when reading systemd.{mount,swap}-extra values.
+
+    :param orig: The original string possibly containing literal ':' characters.
+    :returns: An escaped string with ':' replaced by '\x3a'.
+    """
+    return orig.replace(":", r"\x3a")
+
+
 def _get_uts_release():
     """
     Return the UTS release (kernel version) of the running system.
@@ -348,9 +359,9 @@ def _build_snapset_mount_list(snapset):
                 continue
             if where in snapset_mounts:
                 snapshot = snapset.snapshot_by_mount_point(where)
-                mounts.append(f"{snapshot.devpath}:{where}:{fstype}:{options}")
+                mounts.append(f"{_escape(snapshot.devpath)}:{_escape(where)}:{fstype}:{_escape(options)}")
             else:
-                mounts.append(f"{what}:{where}:{fstype}:{options}")
+                mounts.append(f"{_escape(what)}:{_escape(where)}:{fstype}:{_escape(options)}")
     return mounts
 
 
@@ -372,7 +383,7 @@ def _build_swap_list():
             what, _, fstype, options, _, _ = parts
             if fstype != "swap":
                 continue
-            swaps.append(f"{what}:{options}")
+            swaps.append(f"{_escape(what)}:{_escape(options)}")
     return swaps
 
 

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -59,6 +59,30 @@ class BootTestsSimple(unittest.TestCase):
             sys_machine_id = id_file.read().strip()
         self.assertEqual(sys_machine_id, boot._get_machine_id())
 
+    def test__escape(self):
+        esc_strings = {
+            ":": r"\x3a",
+            "nothingtodo": r"nothingtodo",
+            "already\\x3aescaped": r"already\x3aescaped",
+            "192.168.123.123:/foo/bar": r"192.168.123.123\x3a/foo/bar",
+            "x-useropt=bar:baz,quux:foo": r"x-useropt=bar\x3abaz,quux\x3afoo",
+            "defaults:somethingelse": r"defaults\x3asomethingelse",
+            "::::": r"\x3a\x3a\x3a\x3a",
+            "fe80::5052:ff:fe40:18a8/64": r"fe80\x3a\x3a5052\x3aff\x3afe40\x3a18a8/64",
+        }
+        for to_esc in esc_strings:
+            esc = boot._escape(to_esc)
+            self.assertEqual(esc, esc_strings[to_esc])
+            self.assertEqual(boot._escape(esc), esc)  # idempotent
+
+    def test__escape_None(self):
+        with self.assertRaises((AttributeError, TypeError)):
+            boot._escape(None)
+
+    def test__escape_not_a_string(self):
+        with self.assertRaises((AttributeError, TypeError)):
+            boot._escape(1)
+
 
 @unittest.skipIf(not have_root(), "requires root privileges")
 class BootTestsBase(unittest.TestCase):


### PR DESCRIPTION
~~Resolves: #570~~

Resolves: #893