### PR TITLE
fsdiff: remove redundant `dest_path` in `used_dests` test

### DIFF
--- a/snapm/fsdiff/engine.py
+++ b/snapm/fsdiff/engine.py
@@ -1233,8 +1233,6 @@ class DiffEngine:
                     continue
                 if dest_path == path:
                     continue
-                if dest_path in used_dests:
-                    continue
 
                 # Found a move: count it
                 moves += 1


### PR DESCRIPTION
Resolves: #953

EDIT: CodeRabbit.ai is violently hallucinating on this trivial cleanup/optimisation. Don't heed its BS.

## Summary by CodeRabbit

* **Bug Fixes**
  * ~~Improved move detection so a destination can be recognised in multiple move operations, leading to more accurate move counts and more diffs classified as moves.~~
  * ~~Adjusted pruning behaviour: some records previously pruned may now be preserved and reported.~~

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->