### PR TITLE
stratis: fix pool limit accounting in {create,delete}_snapshot()

### DIFF
--- a/snapm/manager/plugins/stratis.py
+++ b/snapm/manager/plugins/stratis.py
@@ -466,7 +466,7 @@ class Stratis(Plugin):
         if self.priority == PLUGIN_NO_PRIORITY:
             self.priority = STRATIS_STATIC_PRIORITY
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-branches
     def discover_snapshots(self):
         """
         Discover snapshots managed by this plugin class.
@@ -487,6 +487,12 @@ class Stratis(Plugin):
             (path, MOPool(info).Name())
             for path, info in pools().search(managed_objects)
         )
+
+        # Initialise pool snapshot counters to 0
+        for pool in path_to_name.values():
+            pool_name = str(pool)
+            if pool_name not in self.pools:
+                self.pools[pool_name] = 0
 
         filesystems_with_props = [
             MOFilesystem(info)
@@ -532,11 +538,9 @@ class Stratis(Plugin):
                     )
                 )
 
+        # Set or update pool snapshot counters (limit checking)
         for snapshot in snapshots:
-            if snapshot.pool_name not in self.pools:
-                self.pools[snapshot.pool_name] = 1
-            else:
-                self.pools[snapshot.pool_name] += 1
+            self.pools[snapshot.pool_name] += 1
 
         if self.limits.snapshots_per_pool > 0:
             for pool, count in self.pools.items():
@@ -707,6 +711,12 @@ class Stratis(Plugin):
                 f"Stratis daemon reported no change creating snapshot {snapshot_name}"
             )
 
+        # Increment or set pool snapshot counter
+        if pool_name in self.pools:
+            self.pools[pool_name] += 1
+        else:
+            self.pools[pool_name] = 1
+
         return StratisSnapshot(
             f"{pool_name}/{snapshot_name}",
             snapset_name,
@@ -791,6 +801,15 @@ class Stratis(Plugin):
                     f"actually destroy some or all of the filesystems "
                     f"requested"
                 )
+            )
+
+        # Decrement pool snapshot counter
+        if pool_name in self.pools:
+            self.pools[pool_name] -= 1
+        else:
+            # This is harmless but indicates a bug (plugin methods called out-of-sequence).
+            self._log_warn(
+                "Deleted untracked snapshot set member: %s/%s", pool_name, fs_name
             )
 
     # pylint: disable=too-many-arguments

--- a/tests/test_stratis.py
+++ b/tests/test_stratis.py
@@ -186,6 +186,28 @@ class StratisTests(unittest.TestCase):
         snapshots = stratis_plugin.discover_snapshots()
         self.assertEqual(len(snapshots), 2)
 
+    def test_stratis_create_delete_pool_accounting(self):
+        # Verify that pool snapshot counters are properly updated around
+        # create/delete operations.
+
+        # Plugin setup
+        stratis_plugin = stratis.Stratis(log, ConfigParser())
+        snapshots = stratis_plugin.discover_snapshots()
+        pool1_count = stratis_plugin.pools["pool1"]
+
+        # Create snapshot via Plugin.create_snapshot()
+        stratis_plugin.start_transaction()
+        stratis_plugin.check_create_snapshot("pool1/fs1", "test", 1721136677, "/opt", "1%SIZE")
+        stratis_plugin.create_snapshot("pool1/fs1", "test", 1721136677, "/opt", "1%SIZE")
+        stratis_plugin.end_transaction()
+
+        # Verify counter incremented
+        self.assertEqual(stratis_plugin.pools["pool1"], pool1_count + 1)
+
+        # Delete snapshot & verify decrement
+        stratis_plugin.delete_snapshot("pool1/fs1-snapset_test_1721136677_-opt")
+        self.assertEqual(stratis_plugin.pools["pool1"], pool1_count)
+
     def test_stratis_can_snapshot_no_stratisd(self):
         systemctl_stop_args = _systemctl_args("stop")
         run(systemctl_stop_args, check=True)


### PR DESCRIPTION
Resolves: #971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot counters per pool are now pre-initialised, incremented only after successful snapshot creation, decremented only after successful deletion, and will emit a warning if a counter is missing.

* **Tests**
  * Added a unit test that verifies pool snapshot counts increase on creation and return to prior values after deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->