### PR TITLE
tests: update Fedora releases in virt_tests matrix 

### DIFF
--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -142,7 +142,7 @@ jobs:
       matrix:
         firmware: [bios, uefi]
         storage: [lvm, lvm-thin]
-        base_os: [fedora42, fedora43, centos-stream9, centos-stream10]
+        base_os: [fedora43, fedora44, centos-stream9, centos-stream10]
     steps:
       - uses: actions/checkout@v4
       - name: Install virt dependencies

--- a/.github/workflows/snapm.yml
+++ b/.github/workflows/snapm.yml
@@ -160,13 +160,13 @@ jobs:
           # Log host virtualization capabilities
           sudo virt-host-validate qemu || true
           if [[ "$BASE_OS" == fedora* ]]; then
-            # fedora: add fedora 42/43
-            OSINFO_COMMIT="91fe868553246b6af94df08db678cc4c9adc693f"
-            sudo wget -O /usr/share/osinfo/os/fedoraproject.org/fedora-42.xml https://gitlab.com/libosinfo/osinfo-db/-/raw/${OSINFO_COMMIT}/data/os/fedoraproject.org/fedora-42.xml.in
+            # fedora: Add Fedora 44
+            OSINFO_COMMIT="a018d7fec08547758ee64cc08d22c9f75b4fedbd"
             sudo wget -O /usr/share/osinfo/os/fedoraproject.org/fedora-43.xml https://gitlab.com/libosinfo/osinfo-db/-/raw/${OSINFO_COMMIT}/data/os/fedoraproject.org/fedora-43.xml.in
+            sudo wget -O /usr/share/osinfo/os/fedoraproject.org/fedora-44.xml https://gitlab.com/libosinfo/osinfo-db/-/raw/${OSINFO_COMMIT}/data/os/fedoraproject.org/fedora-44.xml.in
             # Sanity-check that osinfo picks up the new definitions
-            osinfo-query os short-id=fedora42 -f short-id || { echo "fedora42 not recognized by osinfo" >&2; exit 1; }
             osinfo-query os short-id=fedora43 -f short-id || { echo "fedora43 not recognized by osinfo" >&2; exit 1; }
+            osinfo-query os short-id=fedora44 -f short-id || { echo "fedora44 not recognized by osinfo" >&2; exit 1; }
           fi
       - name: Install Seabios bios.bin into /usr/share/qemu
         if: ${{ matrix.firmware == 'bios' }}


### PR DESCRIPTION
Fedora 42 is now EoL since the release of F44: update the virt_tests matrix & osinfo-db configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded virtualisation testing to include Fedora 44 alongside Fedora 43 and CentOS Stream.
  - Added validation to confirm Fedora 43 and Fedora 44 are correctly recognised during test setup.

- **Chores**
  - Updated automated test provisioning to use current Fedora operating system definitions, improving coverage for supported Fedora environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->